### PR TITLE
Added command "lock_exp"

### DIFF
--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -14,6 +14,7 @@ namespace DebugToolkit.Commands
     {
 
         internal static bool noEnemies = false;
+        internal static bool lockExp = false;
         internal static ulong seed;
 
         internal static DirectorCard nextBoss;
@@ -81,6 +82,21 @@ namespace DebugToolkit.Commands
                 SceneDirector.onPrePopulateSceneServer -= Hooks.OnPrePopulateSetMonsterCreditZero;
             }
             Log.MessageNetworked("No_enemies set to " + CurrentRun.noEnemies, args);
+        }
+
+        [ConCommand(commandName = "lock_exp", flags = ConVarFlags.ExecuteOnServer, helpText = "Toggle Experience gain. " + Lang.LOCKEXP_ARGS)]
+        private static void CCLockExperience(ConCommandArgs args)
+        {
+            lockExp = !lockExp;
+            if (lockExp)
+            {
+                On.RoR2.ExperienceManager.AwardExperience += Hooks.DenyExperience;
+            } 
+            else
+            {
+                On.RoR2.ExperienceManager.AwardExperience -= Hooks.DenyExperience;
+            }
+            Log.MessageNetworked("lock_exp set to " + CurrentRun.lockExp, args);
         }
 
         [ConCommand(commandName = "kill_all", flags = ConVarFlags.ExecuteOnServer, helpText = "Kill all entities on the specified team. " + Lang.KILLALL_ARGS)]

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -273,5 +273,10 @@ namespace DebugToolkit
             //Note that this is not a hook, but an event subscription.
             director.SetFieldValue("monsterCredit", 0);
         }
+
+        internal static void DenyExperience(On.RoR2.ExperienceManager.orig_AwardExperience orig, ExperienceManager self, Vector3 origin, CharacterBody body, ulong amount)
+        {
+            return;
+        }
     }
 }

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -19,6 +19,7 @@
             GOD_ARGS = "Requires 0 arguments: god",
             NOCLIP_ARGS = "Requires 0 arguments: noclip",
             CURSORTELEPORT_ARGS = "Requires 0 arguments: teleport_on_cursor",
+            LOCKEXP_ARGS = "Requires 0 arguments: lock_exp",
             KICK_ARGS = "Requires 1 argument: ({PlayerID:self}|{Playername})",
             KILLALL_ARGS = "Requires 0 arguments: kill_all {TeamIndex:2/Monster}",
             NEXTBOSS_ARGS = "Requires 1 argument: next_boss ({localised_object_name}|{DirectorCard}) {(int)Count:1} {EliteIndex:-1/None}",


### PR DESCRIPTION
I think I put the command in the right place anyway. Likely needs additional testing.

Having the method simply `return` seems to be fine because the game also just `return`s when it can't find a `body.master`.

Testing worked with: killing enemies, Teleporter's converting money to exp. Also restores back to normal once the command is disabled.
