### PR TITLE
Added a reference to the temporary game object so it could be destroy…

### DIFF
--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -362,7 +362,9 @@ namespace DebugToolkit.Commands
 
                 if (inventory)
                 {
-                    inventory.CopyItemsFrom(new GameObject().AddComponent<Inventory>());
+                    var tempObj = new GameObject();
+                    inventory.CopyItemsFrom(tempObj.AddComponent<Inventory>());
+                    UnityEngine.Object.Destroy(tempObj);
                     Log.MessageNetworked("Removing inventory", args);
                 }
 


### PR DESCRIPTION
…ed afterwards
Unknown how well it propogates in multiplayer, but since inventory syncing is the server, it's probably fine.

Causes pollution of GameObjects in scene.
Release:
![image](https://user-images.githubusercontent.com/72328339/145701522-0cf41440-f26f-4428-9d76-e5cdd2f03471.png)
Fix:
![image](https://user-images.githubusercontent.com/72328339/145701526-7738fe85-eff2-464c-9036-3f0a7503f604.png)
