### PR TITLE
CCSceneList patch

### DIFF
--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -36,7 +36,7 @@ namespace DebugToolkit
             RoR2Application.onLoad += ArgsAutoCompletion.GatherCommandsAndFillStaticArgs;
             IL.RoR2.UI.ConsoleWindow.Update += SmoothDropDownSuggestionNavigation;
             IL.RoR2.Networking.NetworkManagerSystem.CCSetScene += EnableCheatsInCCSetScene;
-            On.RoR2.Networking.NetworkManagerSystem.CCSceneList += NetworkManagerSystem_CCSceneList;
+            On.RoR2.Networking.NetworkManagerSystem.CCSceneList += OverrideVanillaSceneList;
 
             // Noclip hooks
             var hookConfig = new HookConfig { ManualApply = true };
@@ -48,14 +48,14 @@ namespace DebugToolkit
             Command_Noclip.origClientChangeScene = Command_Noclip.OnClientChangeSceneHook.GenerateTrampoline<Command_Noclip.d_ClientChangeScene>();
         }
 
-        private static void NetworkManagerSystem_CCSceneList(On.RoR2.Networking.NetworkManagerSystem.orig_CCSceneList orig, ConCommandArgs args)
+        private static void OverrideVanillaSceneList(On.RoR2.Networking.NetworkManagerSystem.orig_CCSceneList orig, ConCommandArgs args)
         {
             StringBuilder stringBuilder = new StringBuilder();
             foreach (var sceneDef in SceneCatalog.allSceneDefs)
             {
-                stringBuilder.Append($"[{sceneDef.sceneDefIndex}] - {sceneDef.baseSceneName}{Environment.NewLine}");
+                stringBuilder.AppendLine($"[{sceneDef.sceneDefIndex}] - {sceneDef.baseSceneName}");
             }
-            Log.Message(stringBuilder);
+            Log.Message(stringBuilder, Log.LogLevel.MessageClientOnly);
         }
 
         private static void EnableCheatsInCCSetScene(ILContext il)

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -50,10 +50,12 @@ namespace DebugToolkit
 
         private static void NetworkManagerSystem_CCSceneList(On.RoR2.Networking.NetworkManagerSystem.orig_CCSceneList orig, ConCommandArgs args)
         {
+            StringBuilder stringBuilder = new StringBuilder();
             foreach (var sceneDef in SceneCatalog.allSceneDefs)
             {
-                Debug.Log($"[{sceneDef.sceneDefIndex}] - {sceneDef.baseSceneName}");
+                stringBuilder.Append($"[{sceneDef.sceneDefIndex}] - {sceneDef.baseSceneName}{Environment.NewLine}");
             }
+            Log.Message(stringBuilder);
         }
 
         private static void EnableCheatsInCCSetScene(ILContext il)

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -36,6 +36,7 @@ namespace DebugToolkit
             RoR2Application.onLoad += ArgsAutoCompletion.GatherCommandsAndFillStaticArgs;
             IL.RoR2.UI.ConsoleWindow.Update += SmoothDropDownSuggestionNavigation;
             IL.RoR2.Networking.NetworkManagerSystem.CCSetScene += EnableCheatsInCCSetScene;
+            On.RoR2.Networking.NetworkManagerSystem.CCSceneList += NetworkManagerSystem_CCSceneList;
 
             // Noclip hooks
             var hookConfig = new HookConfig { ManualApply = true };
@@ -45,6 +46,14 @@ namespace DebugToolkit
             Command_Noclip.OnClientChangeSceneHook = new Hook(typeof(UnityEngine.Networking.NetworkManager).GetMethodCached("ClientChangeScene"),
                 typeof(Command_Noclip).GetMethodCached("DisableOnClientSceneChange"),hookConfig);
             Command_Noclip.origClientChangeScene = Command_Noclip.OnClientChangeSceneHook.GenerateTrampoline<Command_Noclip.d_ClientChangeScene>();
+        }
+
+        private static void NetworkManagerSystem_CCSceneList(On.RoR2.Networking.NetworkManagerSystem.orig_CCSceneList orig, ConCommandArgs args)
+        {
+            foreach (var sceneDef in SceneCatalog.allSceneDefs)
+            {
+                Debug.Log($"[{sceneDef.sceneDefIndex}] - {sceneDef.baseSceneName}");
+            }
         }
 
         private static void EnableCheatsInCCSetScene(ILContext il)


### PR DESCRIPTION
CCSceneList isn't properly setup for Survivors Of The Void and will only output one scene name
![image](https://user-images.githubusercontent.com/72328339/157781896-ec6e224c-976d-40c9-80b4-fe75094a7b48.png)

I've fully overriden the hook to take from the SceneCatalog instead.
![image](https://user-images.githubusercontent.com/72328339/157782014-32e621da-86ce-494c-a722-e9f07d044d8d.png)

Logging using StringBuilder resulted in a performance increase on my machine compared to Logging each line separately. 

Add to README.md under Hooks:
* `On.RoR2.Networking.NetworkManagerSystem.CCSceneList` - To properly list the valid scenes.