### PR TITLE
New Commands: list_skin, loadout_set_skin_variant

### DIFF
--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -104,7 +104,7 @@ namespace DebugToolkit.Commands
                                 continue;
                             skinDefs.Add(skin);
                             var langInvar = StringFinder.GetLangInvar(skin.nameToken);
-                            sb.AppendLine($"\t[{skin.skinIndex}] {skin.name}={langInvar}");
+                            sb.AppendLine($"[{skin.skinIndex}] {skin.name}={langInvar}");
                         }
                         break;
                     default:

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using static DebugToolkit.Log;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace DebugToolkit.Commands
 {
@@ -73,31 +74,41 @@ namespace DebugToolkit.Commands
             Log.Message(sb);
         }
 
-        [ConCommand(commandName = "list_skin", flags = ConVarFlags.None, helpText = "List all bodies with skins" + Lang.LISTBODY_ARGS)]
+        [ConCommand(commandName = "list_skin", flags = ConVarFlags.None, helpText = "List all bodies with skins. " + Lang.LISTSKIN_ARGS)]
         private static void CCListSkin(ConCommandArgs args)
         {
-            string langInvar;
+            //string langInvar;
             StringBuilder sb = new StringBuilder();
-            string bodyName = null;
             if (args.Count == 0)
             {
                 args.userArgs.Add(Lang.ALL); //simple
             }
             if (args.Count >= 1)
             {
-                bodyName = args.GetArgString(0);
+                string bodyName = args.GetArgString(0);
                 string upperBodyName = bodyName.ToUpperInvariant();
 
                 switch (upperBodyName)
                 {
-                    case Lang.ALL:
+                    case "BODY":
                         foreach (var bodyComponent in BodyCatalog.allBodyPrefabBodyBodyComponents)
                         {
                             AppendSkinIndices(ref sb, bodyComponent);
                         }
                         break;
+                    case Lang.ALL:
+                        HashSet<SkinDef> skinDefs = new HashSet<SkinDef>();
+                        foreach (var skin in SkinCatalog.allSkinDefs)
+                        {
+                            if (skinDefs.Contains(skin))
+                                continue;
+                            skinDefs.Add(skin);
+                            var langInvar = StringFinder.GetLangInvar(skin.nameToken);
+                            sb.AppendLine($"\t[{skin.skinIndex}] {skin.name}={langInvar}");
+                        }
+                        break;
                     default:
-                        CharacterBody body = null;
+                        CharacterBody body;
                         if (upperBodyName == "SELF")
                         {
                             if (args.sender == null)
@@ -159,7 +170,7 @@ namespace DebugToolkit.Commands
                 foreach (var skinDef in skins)
                 {
                     langInvar = StringFinder.GetLangInvar(skinDef.nameToken);
-                    stringBuilder.AppendLine($"-[{i}={skinDef.skinIndex}] {skinDef.name}={langInvar}");
+                    stringBuilder.AppendLine($"\t[{i}={skinDef.skinIndex}] {skinDef.name}={langInvar}");
                     i++;
                 }
             }

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -19,6 +19,7 @@
             GOD_ARGS = "Requires 0 arguments: god",
             NOCLIP_ARGS = "Requires 0 arguments: noclip",
             CURSORTELEPORT_ARGS = "Requires 0 arguments: teleport_on_cursor",
+            LOADOUTSKIN_ARGS = "Requires 1 argument: loadout_set_skin_variant {skinIndex} {localised_objectname:self}",
             LOCKEXP_ARGS = "Requires 0 arguments: lock_exp",
             KICK_ARGS = "Requires 1 argument: ({PlayerID:self}|{Playername})",
             KILLALL_ARGS = "Requires 0 arguments: kill_all {TeamIndex:2/Monster}",
@@ -45,7 +46,8 @@
             LISTEQUIP_ARGS = "List all equipment items and their IDs",
             LISTAI_ARGS = "List all Masters and their language invariants",
             LISTBODY_ARGS  = "List all Bodies and their language invariants",
-            LISTPLAYER_ARGS = "List all players and their ID"
+            LISTPLAYER_ARGS = "List all players and their ID",
+            LISTSKIN_ARGS  = "Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"self\"|:\"all\"})"
             ;
 
         public const string
@@ -65,6 +67,7 @@
             NOCLIP_TOGGLE = "Noclip toggled to {0}",
             PARTIALIMPLEMENTATION_WARNING = "WARNING: PARTIAL IMPLEMENTATION. WIP.",
             PLAYER_DEADRESPAWN = "Player is will spawn as the specified body next round. (Use 'respawn' to skip the wait)",
+            PLAYER_SKINCHANGERESPAWN = "Player will spawn with the specified skin next round. (Use 'respawn' to skip the wait)",
             PLAYER_NOTFOUND = "Specified player does not exist",
             PORTAL_NOTFOUND = "The specified portal could not be found. Valid portals: 'blue','gold','celestial','null','void','deepvoid','all'",
             RUNSETSTAGESCLEARED_HELP = "Sets the amount of stages cleared. This does not change the current stage.",

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -19,7 +19,7 @@
             GOD_ARGS = "Requires 0 arguments: god",
             NOCLIP_ARGS = "Requires 0 arguments: noclip",
             CURSORTELEPORT_ARGS = "Requires 0 arguments: teleport_on_cursor",
-            LOADOUTSKIN_ARGS = "Requires 1 argument: loadout_set_skin_variant {skinIndex} {localised_objectname:self}",
+            LOADOUTSKIN_ARGS = "Requires 2 argument: loadout_set_skin_variant {skinIndex} {localised_objectname|self}",
             LOCKEXP_ARGS = "Requires 0 arguments: lock_exp",
             KICK_ARGS = "Requires 1 argument: ({PlayerID:self}|{Playername})",
             KILLALL_ARGS = "Requires 0 arguments: kill_all {TeamIndex:2/Monster}",
@@ -47,7 +47,7 @@
             LISTAI_ARGS = "List all Masters and their language invariants",
             LISTBODY_ARGS  = "List all Bodies and their language invariants",
             LISTPLAYER_ARGS = "List all players and their ID",
-            LISTSKIN_ARGS  = "Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"self\"|:\"all\"})"
+            LISTSKIN_ARGS  = "Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"body\" (separated by body)|\"self\"|:\"all\"})"
             ;
 
         public const string

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -19,7 +19,7 @@
             GOD_ARGS = "Requires 0 arguments: god",
             NOCLIP_ARGS = "Requires 0 arguments: noclip",
             CURSORTELEPORT_ARGS = "Requires 0 arguments: teleport_on_cursor",
-            LOADOUTSKIN_ARGS = "Requires 2 argument: loadout_set_skin_variant {skinIndex} {localised_objectname|self}",
+            LOADOUTSKIN_ARGS = "Requires 2 argument: loadout_set_skin_variant {localised_objectname|self} {skinIndex}",
             LOCKEXP_ARGS = "Requires 0 arguments: lock_exp",
             KICK_ARGS = "Requires 1 argument: ({PlayerID:self}|{Playername})",
             KILLALL_ARGS = "Requires 0 arguments: kill_all {TeamIndex:2/Monster}",

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -18,6 +18,7 @@ namespace DebugToolkit
         private static readonly Dictionary<string, string[]> MasterAlias = new Dictionary<string, string[]>();
         private static readonly Dictionary<string, string[]> ItemAlias = new Dictionary<string, string[]>();
         private static readonly Dictionary<string, string[]> EquipAlias = new Dictionary<string, string[]>();
+        private static readonly Dictionary<string, string[]> SkinAlias = new Dictionary<string, string[]>();
         private static StringFinder instance;
         private static readonly List<DirectorCard> characterSpawnCard = new List<DirectorCard>();
         private static List<InteractableSpawnCard> interactableSpawnCards = new List<InteractableSpawnCard>();
@@ -178,6 +179,41 @@ namespace DebugToolkit
                 }
             }
             return ItemIndex.None;
+        }
+
+        /// <summary>
+        /// Returns an SkinIndex when provided with a partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
+        /// <returns>Returns the SkinIndex if a match is found, or returns SkinIndex.None</returns>
+        public SkinIndex GetSkinFromPartial(string name)
+        {
+            string langInvar;
+            foreach (KeyValuePair<string, string[]> dictEnt in SkinAlias)
+            {
+                foreach (string alias in dictEnt.Value)
+                {
+                    if (alias.ToUpper().Equals(name.ToUpper()))
+                    {
+                        name = dictEnt.Key;
+
+                    }
+                }
+            }
+            if (Enum.TryParse(name, true, out SkinIndex foundSkin) && foundSkin < (SkinIndex)SkinCatalog.skinCount)
+            {
+                return foundSkin;
+            }
+
+            foreach (var skin in typeof(SkinCatalog).GetFieldValue<SkinDef[]>("allSkinDefs"))
+            {
+                langInvar = GetLangInvar(skin.nameToken.ToUpper());
+                if (skin.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(RemoveSpacesAndAlike(name.ToUpper())))
+                {
+                    return skin.skinIndex;
+                }
+            }
+            return SkinIndex.None;
         }
 
         /// <summary>


### PR DESCRIPTION
**Describe your new command**
`list_skin`: Lists all skins
Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"body\" (separated by body)|\"self\"|:\"all\"})
Usage:
`list_skin/list_skin all` - Lists all skins
`list_skin body` lists all bodies that have skins, and their skins indented
![image](https://user-images.githubusercontent.com/72328339/164211974-32c15fa6-fea7-4f43-a886-c70a1697ea05.png)

`list_skin bodyName` lists all skins for the specified body name
![image](https://user-images.githubusercontent.com/72328339/164211809-72f0e9fa-4c8c-4951-b902-215a05b01ea4.png)
`list_skin self` lists all skins for (by whatever it gets first):
  * your current body
  * your current bodyPrefab
  * your networked body preference

![image](https://user-images.githubusercontent.com/72328339/164212151-fdcaaa9b-43e9-402d-9dce-fa75940bf815.png)


**Use cases**
listing all skins available, debugging probably

**Describe your new command**
`loadout_set_skin_variant`: changes the current skin of the character and for the userprofile
Requires 2 argument: loadout_set_skin_variant {localised_objectname|self} {skinIndex}
Usage:
`loadout_set_skin_variant self 1` - Changes the current body's skin to it's second skin
`loadout_set_skin_Variant commando 0` Changes commando's skin to the default skin

**Use cases**
Quicker iteration of testing skins. (not mentioned) requires a respawn for mods to have more accurate preview.
Video preview: https://www.youtube.com/watch?v=w7TDsciCHnc
Inaccuracy: dotflare LostThroughTimeSkinPack chose Commando's "Dressed to Kill" skin, switched to Default. I think its due to the mesh having extra objects? Anyways as long as you get respawned its fine.
![image](https://user-images.githubusercontent.com/72328339/164212753-65a33c11-0996-4b29-8fd9-6c54d0499dfd.png)