### PR TITLE
Added filtering to listing commands (list_item, etc)

### DIFF
--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -11,7 +11,7 @@ namespace DebugToolkit.Commands
 {
     class Items
     {
-        [ConCommand(commandName = "list_item", flags = ConVarFlags.None, helpText = "List all items and their availability.")]
+        [ConCommand(commandName = "list_item", flags = ConVarFlags.None, helpText = "List all items and their availability. "+ Lang.LISTITEM_ARGS)]
         private static void CCListItem(ConCommandArgs args)
         {
             var sb = new StringBuilder();
@@ -38,7 +38,7 @@ namespace DebugToolkit.Commands
             Log.Message(sb.ToString());
         }
 
-        [ConCommand(commandName = "list_equip", flags = ConVarFlags.None, helpText = "List all items and their availability.")]
+        [ConCommand(commandName = "list_equip", flags = ConVarFlags.None, helpText = "List all equipment and their availability. " + Lang.LISTEQUIP_ARGS)]
         private static void CCListEquip(ConCommandArgs args)
         {
             var sb = new StringBuilder();

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -19,7 +19,7 @@ namespace DebugToolkit.Commands
             if (args.Count > 0)
             {
                 itemList = (IEnumerable<ItemIndex>)StringFinder.Instance.GetItemsFromPartial(args.GetArgString(0));
-                if (itemList.Count() == 0 || itemList.First() == ItemIndex.None) sb.AppendLine($"No item that matches \"{args.GetArgString(0)}\".");
+                if (itemList.Count() == 0) sb.AppendLine($"No item that matches \"{args.GetArgString(0)}\".");
             } else
             {
                 itemList = (IEnumerable<ItemIndex>)ItemCatalog.allItems;
@@ -46,7 +46,7 @@ namespace DebugToolkit.Commands
             if (args.Count > 0)
             {
                 list = StringFinder.Instance.GetEquipsFromPartial(args.GetArgString(0));
-                    if (list.Count() == 0 || list.First() == EquipmentIndex.None) sb.AppendLine($"No equipment that matches \"{args.GetArgString(0)}\".");
+                    if (list.Count() == 0) sb.AppendLine($"No equipment that matches \"{args.GetArgString(0)}\".");
             }
             else
             {

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -2,6 +2,7 @@
 using RoR2;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 using static DebugToolkit.Log;
@@ -11,10 +12,19 @@ namespace DebugToolkit.Commands
     class Items
     {
         [ConCommand(commandName = "list_item", flags = ConVarFlags.None, helpText = "List all items and their availability.")]
-        private static void CCListItem(ConCommandArgs _)
+        private static void CCListItem(ConCommandArgs args)
         {
             var sb = new StringBuilder();
-            foreach (var itemIndex in (IEnumerable<ItemIndex>)ItemCatalog.allItems)
+            IEnumerable<ItemIndex> itemList;
+            if (args.Count > 0)
+            {
+                itemList = (IEnumerable<ItemIndex>)StringFinder.Instance.GetItemsFromPartial(args.GetArgString(0));
+                if (itemList.Count() == 0 || itemList.First() == ItemIndex.None) sb.AppendLine($"No item that matches \"{args.GetArgString(0)}\".");
+            } else
+            {
+                itemList = (IEnumerable<ItemIndex>)ItemCatalog.allItems;
+            }
+            foreach (var itemIndex in itemList)
             {
                 var definition = ItemCatalog.GetItemDef(itemIndex);
                 string enabled = false.ToString();
@@ -29,10 +39,21 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "list_equip", flags = ConVarFlags.None, helpText = "List all items and their availability.")]
-        private static void CCListEquip(ConCommandArgs _)
+        private static void CCListEquip(ConCommandArgs args)
         {
             var sb = new StringBuilder();
-            foreach (var equipmentIndex in (IEnumerable<EquipmentIndex>)EquipmentCatalog.allEquipment)
+            IEnumerable<EquipmentIndex> list;
+            if (args.Count > 0)
+            {
+                list = StringFinder.Instance.GetEquipsFromPartial(args.GetArgString(0));
+                    if (list.Count() == 0 || list.First() == EquipmentIndex.None) sb.AppendLine($"No equipment that matches \"{args.GetArgString(0)}\".");
+            }
+            else
+            {
+                list = EquipmentCatalog.allEquipment;
+            }
+
+            foreach (var equipmentIndex in list)
             {
                 var definition = EquipmentCatalog.GetEquipmentDef(equipmentIndex);
                 string enabled = false.ToString();

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -1,6 +1,8 @@
 ﻿using RoR2;
+using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Xml.Linq;
 using UnityEngine;
 using static DebugToolkit.Log;
 
@@ -8,13 +10,35 @@ namespace DebugToolkit.Commands
 {
     class Lists
     {
-        [ConCommand(commandName = "list_interactables", flags = ConVarFlags.None, helpText = "Lists all interactables.")]
-        private static void CCList_interactables(ConCommandArgs _)
+        [ConCommand(commandName = "list_interactables", flags = ConVarFlags.None, helpText = "Lists all interactables. "+Lang.LISTINTERACTABLE_ARGS)]
+        private static void CCList_interactables(ConCommandArgs args)
         {
+            //edits based on StringFinder.GetInteractableSpawnCard()
             StringBuilder s = new StringBuilder();
-            foreach (InteractableSpawnCard isc in StringFinder.Instance.InteractableSpawnCards)
+            int resultCount = 0;
+            if (args.Count > 0)
             {
-                s.AppendLine(isc.name.Replace("isc", string.Empty));
+                string name = args.GetArgString(0);
+                // s.AppendLine($"Checking for: ");
+                foreach (InteractableSpawnCard isc in StringFinder.Instance.InteractableSpawnCards)
+                {
+                    var iscName = isc.name.ToUpper().Replace("ISC", string.Empty);
+                    if (iscName.Equals(name.ToUpper().Replace("ISC", string.Empty)) || iscName.Contains(name.ToUpper()))
+                    {
+                        resultCount++;
+                        s.AppendLine(isc.name.Replace("isc", string.Empty));
+                    }
+                }
+                if (resultCount == 0)
+                {
+                    s.AppendLine($"No interactables found that match \"{name}\".");
+                }
+            } else
+            {
+                foreach (InteractableSpawnCard isc in StringFinder.Instance.InteractableSpawnCards)
+                {
+                    s.AppendLine(isc.name.Replace("isc", string.Empty));
+                }
             }
             Log.Message(s.ToString(), LogLevel.MessageClientOnly);
         }

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -1,6 +1,7 @@
 ﻿using RoR2;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using UnityEngine;
@@ -15,30 +16,21 @@ namespace DebugToolkit.Commands
         {
             //edits based on StringFinder.GetInteractableSpawnCard()
             StringBuilder s = new StringBuilder();
-            int resultCount = 0;
+            IEnumerable<InteractableSpawnCard> list;
             if (args.Count > 0)
             {
-                string name = args.GetArgString(0);
-                // s.AppendLine($"Checking for: ");
-                foreach (InteractableSpawnCard isc in StringFinder.Instance.InteractableSpawnCards)
-                {
-                    var iscName = isc.name.ToUpper().Replace("ISC", string.Empty);
-                    if (iscName.Equals(name.ToUpper().Replace("ISC", string.Empty)) || iscName.Contains(name.ToUpper()))
-                    {
-                        resultCount++;
-                        s.AppendLine(isc.name.Replace("isc", string.Empty));
-                    }
-                }
-                if (resultCount == 0)
-                {
-                    s.AppendLine($"No interactables found that match \"{name}\".");
-                }
+                list = StringFinder.Instance.GetInteractableSpawnCards(args.GetArgString(0));
+
+                if (list.Count() == 0)
+                    s.AppendLine($"No interactables found that match \"{args.GetArgString(0)}\".");
             } else
             {
-                foreach (InteractableSpawnCard isc in StringFinder.Instance.InteractableSpawnCards)
-                {
-                    s.AppendLine(isc.name.Replace("isc", string.Empty));
-                }
+                list = StringFinder.Instance.InteractableSpawnCards;
+            }
+
+            foreach (InteractableSpawnCard isc in list)
+            {
+                s.AppendLine(isc.name.Replace("isc", string.Empty));
             }
             Log.Message(s.ToString(), LogLevel.MessageClientOnly);
         }

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -10,7 +10,7 @@ namespace DebugToolkit.Commands
 {
     class Lists
     {
-        [ConCommand(commandName = "list_interactables", flags = ConVarFlags.None, helpText = "Lists all interactables. "+Lang.LISTINTERACTABLE_ARGS)]
+        [ConCommand(commandName = "list_interactables", flags = ConVarFlags.None, helpText = Lang.LISTINTERACTABLE_ARGS)]
         private static void CCList_interactables(ConCommandArgs args)
         {
             //edits based on StringFinder.GetInteractableSpawnCard()
@@ -58,31 +58,78 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "list_AI", flags = ConVarFlags.None, helpText = Lang.LISTAI_ARGS)]
-        private static void CCListAI(ConCommandArgs _)
+        private static void CCListAI(ConCommandArgs args)
         {
             string langInvar;
             int i = 0;
             StringBuilder sb = new StringBuilder();
-            foreach (var master in MasterCatalog.allAiMasters)
+            int resultCount = 0;
+            if (args.Count > 0)
             {
-                langInvar = StringFinder.GetLangInvar(master.bodyPrefab.GetComponent<CharacterBody>().baseNameToken);
-                sb.AppendLine($"[{i}]{master.name}={langInvar}");
-                i++;
+                string name = args.GetArgString(0);
+                foreach (var master in MasterCatalog.allAiMasters)
+                {
+                    var masterName = master.name.ToUpper();
+                    if (int.TryParse(name, out int iName) && i == iName || masterName.Equals(name.ToUpper().Replace("MASTER", string.Empty)) || masterName.Contains(name.ToUpper()))
+                    {
+                        resultCount++;
+                        langInvar = StringFinder.GetLangInvar(master.bodyPrefab.GetComponent<CharacterBody>().baseNameToken);
+                        sb.AppendLine($"[{i}]{master.name}={langInvar}");
+                    }
+                    i++;
+                }
+                if (resultCount == 0)
+                {
+                    sb.AppendLine($"No masters found that match \"{name}\".");
+                }
+            } else
+            {
+                foreach (var master in MasterCatalog.allAiMasters)
+                {
+                    langInvar = StringFinder.GetLangInvar(master.bodyPrefab.GetComponent<CharacterBody>().baseNameToken);
+                    sb.AppendLine($"[{i}]{master.name}={langInvar}");
+                    i++;
+                }
             }
             Log.Message(sb);
+
         }
 
         [ConCommand(commandName = "list_Body", flags = ConVarFlags.None, helpText = Lang.LISTBODY_ARGS)]
-        private static void CCListBody(ConCommandArgs _)
+        private static void CCListBody(ConCommandArgs args)
         {
-            string langInvar;
-            int i = 0;
             StringBuilder sb = new StringBuilder();
-            foreach (var body in BodyCatalog.allBodyPrefabBodyBodyComponents)
+            string langInvar;
+            int resultCount = 0;
+            int i = 0;
+
+            if (args.Count > 0)
             {
-                langInvar = StringFinder.GetLangInvar(body.baseNameToken);
-                sb.AppendLine($"[{i}]{body.name}={langInvar}");
-                i++;
+                string name = args.GetArgString(0);
+                foreach (var body in BodyCatalog.allBodyPrefabBodyBodyComponents)
+                {
+                    var upperBodyName = body.name.ToUpper();
+                    if (int.TryParse(name, out int iName) && i == iName || upperBodyName.Equals(name.ToUpper().Replace("BODY", string.Empty)) || upperBodyName.Contains(name.ToUpper()) )
+                    {
+                        langInvar = StringFinder.GetLangInvar(body.baseNameToken);
+                        sb.AppendLine($"[{i}]{body.name}={langInvar}");
+                        resultCount++;
+                    }
+                    i++;
+                }
+                if (resultCount == 0)
+                {
+                    sb.AppendLine($"No bodies found that match \"{name}\".");
+                }
+            }
+            else
+            {
+                foreach (var body in BodyCatalog.allBodyPrefabBodyBodyComponents)
+                {
+                    langInvar = StringFinder.GetLangInvar(body.baseNameToken);
+                    sb.AppendLine($"[{i}]{body.name}={langInvar}");
+                    i++;
+                }
             }
             Log.Message(sb);
         }
@@ -98,7 +145,7 @@ namespace DebugToolkit.Commands
             Log.Message(sb);
         }
 
-        [ConCommand(commandName = "list_skin", flags = ConVarFlags.None, helpText = "List all bodies with skins. " + Lang.LISTSKIN_ARGS)]
+        [ConCommand(commandName = "list_skin", flags = ConVarFlags.None, helpText = Lang.LISTSKIN_ARGS)]
         private static void CCListSkin(ConCommandArgs args)
         {
             //string langInvar;

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -42,8 +42,8 @@
             ;
 
         public const string
-            LISTITEM_ARGS = "List all item names and their IDs. Requires 0 argument: list_ai {query}",
-            LISTEQUIP_ARGS = "List all equipment items and their IDs. Requires 0 argument: list_ai {query}",
+            LISTITEM_ARGS = "List all item names and their IDs. Requires 0 argument: list_item {query}",
+            LISTEQUIP_ARGS = "List all equipment items and their IDs. Requires 0 argument: list_equip {query}",
             LISTAI_ARGS = "List all Masters and their language invariants. Requires 0 argument: list_ai {query}",
             LISTBODY_ARGS = "List all Bodies and their language invariants. Requires 0 argument: list_body {query}",
             LISTPLAYER_ARGS = "List all players and their ID",

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -47,7 +47,8 @@
             LISTAI_ARGS = "List all Masters and their language invariants",
             LISTBODY_ARGS = "List all Bodies and their language invariants",
             LISTPLAYER_ARGS = "List all players and their ID",
-            LISTSKIN_ARGS = "Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"body\" (separated by body)|\"self\"|:\"all\"})"
+            LISTSKIN_ARGS = "Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"body\" (separated by body)|\"self\"|:\"all\"})",
+            LISTINTERACTABLE_ARGS = "Requires 0 argument: list_interactables {localised_object_name}"
             ;
 
         public const string

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -42,13 +42,13 @@
             ;
 
         public const string
-            LISTITEM_ARGS = "List all item names and their IDs",
-            LISTEQUIP_ARGS = "List all equipment items and their IDs",
-            LISTAI_ARGS = "List all Masters and their language invariants",
-            LISTBODY_ARGS = "List all Bodies and their language invariants",
+            LISTITEM_ARGS = "List all item names and their IDs. Requires 0 argument: list_ai {query}",
+            LISTEQUIP_ARGS = "List all equipment items and their IDs. Requires 0 argument: list_ai {query}",
+            LISTAI_ARGS = "List all Masters and their language invariants. Requires 0 argument: list_ai {query}",
+            LISTBODY_ARGS = "List all Bodies and their language invariants. Requires 0 argument: list_body {query}",
             LISTPLAYER_ARGS = "List all players and their ID",
-            LISTSKIN_ARGS = "Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"body\" (separated by body)|\"self\"|:\"all\"})",
-            LISTINTERACTABLE_ARGS = "Requires 0 argument: list_interactables {localised_object_name}"
+            LISTSKIN_ARGS = "List all bodies with skins. Requires 0 arguments: list_skin ({localised_objectname}|\"all\"|\"body\" (separated by body)|\"self\"|:\"all\"})",
+            LISTINTERACTABLE_ARGS = "Lists all interactables. Requires 0 argument: list_interactables {query}"
             ;
 
         public const string

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -347,7 +347,7 @@ namespace DebugToolkit
         {
             foreach (InteractableSpawnCard isc in interactableSpawnCards)
             {
-                if (isc.name.ToUpper().Replace("ISC", String.Empty).Equals(name.ToUpper().Replace("ISC", string.Empty)) || isc.name.ToUpper().Replace("isc", String.Empty).Contains(name.ToUpper()))
+                if (isc.name.ToUpper().Replace("ISC", String.Empty).Equals(name.ToUpper().Replace("ISC", string.Empty)) || isc.name.ToUpper().Replace("ISC", String.Empty).Contains(name.ToUpper()))
                 {
                     return isc;
                 }
@@ -366,7 +366,7 @@ namespace DebugToolkit
             HashSet<InteractableSpawnCard> set = new HashSet<InteractableSpawnCard>();
             foreach (InteractableSpawnCard isc in interactableSpawnCards)
             {
-                if (isc.name.ToUpper().Replace("ISC", String.Empty).Equals(name.ToUpper().Replace("ISC", string.Empty)) || isc.name.ToUpper().Replace("isc", String.Empty).Contains(name.ToUpper()))
+                if (isc.name.ToUpper().Replace("ISC", String.Empty).Equals(name.ToUpper().Replace("ISC", string.Empty)) || isc.name.ToUpper().Replace("ISC", String.Empty).Contains(name.ToUpper()))
                 {
                     set.Add(isc);
                 }

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -169,6 +169,43 @@ namespace DebugToolkit
         }
 
         /// <summary>
+        /// Returns an array of EquipmentIndex's when provided with a partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
+        /// <returns>Returns the EquiptmentIndex if a match is found, or returns EquiptmentIndex.None</returns>
+        public EquipmentIndex[] GetEquipsFromPartial(string name)
+        {
+            var set = new HashSet<EquipmentIndex>();
+            string langInvar;
+            foreach (KeyValuePair<string, string[]> dictEnt in EquipAlias)
+            {
+                foreach (string alias in dictEnt.Value)
+                {
+                    if (alias.ToUpper().Equals(name.ToUpper()))
+                    {
+                        name = dictEnt.Key;
+                    }
+                }
+            }
+
+            if (Enum.TryParse(name, true, out EquipmentIndex foundEquip) && EquipmentCatalog.IsIndexValid(foundEquip))
+            {
+                set.Add(foundEquip);
+            }
+
+            foreach (var equip in typeof(EquipmentCatalog).GetFieldValue<EquipmentDef[]>("equipmentDefs"))
+            {
+                langInvar = GetLangInvar(equip.nameToken.ToUpper());
+                if (equip.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(RemoveSpacesAndAlike(name.ToUpper())))
+                {
+                    set.Add(equip.equipmentIndex);
+                }
+            }
+            if (set.Count == 0) set.Add(EquipmentIndex.None);
+            return set.ToArray();
+        }
+
+        /// <summary>
         /// Returns an ItemIndex when provided with a partial/invariant.
         /// </summary>
         /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
@@ -201,6 +238,43 @@ namespace DebugToolkit
                 }
             }
             return ItemIndex.None;
+        }
+
+        /// <summary>
+        /// Returns an array of ItemIndex's when provided with a partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
+        /// <returns>Returns the ItemIndex if a match is found, or returns ItemIndex.None</returns>
+        public ItemIndex[] GetItemsFromPartial(string name)
+        {
+            var set = new HashSet<ItemIndex>();
+            string langInvar;
+            foreach (KeyValuePair<string, string[]> dictEnt in ItemAlias)
+            {
+                foreach (string alias in dictEnt.Value)
+                {
+                    if (alias.ToUpper().Equals(name.ToUpper()))
+                    {
+                        name = dictEnt.Key;
+
+                    }
+                }
+            }
+            if (Enum.TryParse(name, true, out ItemIndex foundItem) && ItemCatalog.IsIndexValid(foundItem))
+            {
+                set.Add(foundItem);
+            }
+
+            foreach (var item in typeof(ItemCatalog).GetFieldValue<ItemDef[]>("itemDefs"))
+            {
+                langInvar = GetLangInvar(item.nameToken.ToUpper());
+                if (item.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(RemoveSpacesAndAlike(name.ToUpper())))
+                {
+                    set.Add(item.itemIndex);
+                }
+            }
+            if (set.Count == 0) set.Add(ItemIndex.None);
+            return set.ToArray();
         }
 
         /// <summary>

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -184,14 +184,14 @@ namespace DebugToolkit
                     if (alias.ToUpper().Equals(name.ToUpper()))
                     {
                         name = dictEnt.Key;
+                        if (Enum.TryParse(name, true, out EquipmentIndex foundEquip) && EquipmentCatalog.IsIndexValid(foundEquip))
+                        {
+                            set.Add(foundEquip);
+                        }
                     }
                 }
             }
 
-            if (Enum.TryParse(name, true, out EquipmentIndex foundEquip) && EquipmentCatalog.IsIndexValid(foundEquip))
-            {
-                set.Add(foundEquip);
-            }
 
             foreach (var equip in typeof(EquipmentCatalog).GetFieldValue<EquipmentDef[]>("equipmentDefs"))
             {
@@ -201,7 +201,7 @@ namespace DebugToolkit
                     set.Add(equip.equipmentIndex);
                 }
             }
-            if (set.Count == 0) set.Add(EquipmentIndex.None);
+            //if (set.Count == 0) set.Add(EquipmentIndex.None);
             return set.ToArray();
         }
 
@@ -256,13 +256,12 @@ namespace DebugToolkit
                     if (alias.ToUpper().Equals(name.ToUpper()))
                     {
                         name = dictEnt.Key;
-
+                        if (Enum.TryParse(name, true, out ItemIndex foundItem) && ItemCatalog.IsIndexValid(foundItem))
+                        {
+                            set.Add(foundItem);
+                        }
                     }
                 }
-            }
-            if (Enum.TryParse(name, true, out ItemIndex foundItem) && ItemCatalog.IsIndexValid(foundItem))
-            {
-                set.Add(foundItem);
             }
 
             foreach (var item in typeof(ItemCatalog).GetFieldValue<ItemDef[]>("itemDefs"))
@@ -273,7 +272,7 @@ namespace DebugToolkit
                     set.Add(item.itemIndex);
                 }
             }
-            if (set.Count == 0) set.Add(ItemIndex.None);
+            //if (set.Count == 0) set.Add(ItemIndex.None);
             return set.ToArray();
         }
 
@@ -355,6 +354,25 @@ namespace DebugToolkit
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns an array of InteractableSpawnCards given a partial spawncard name
+        /// </summary>
+        /// <param name="name">Matches a specific spawncard prior to matching a partial.</param>
+        /// <returns>Returns a InteractableSpawncard or throws exception.</returns>
+        public InteractableSpawnCard[] GetInteractableSpawnCards(string name)
+        {
+            HashSet<InteractableSpawnCard> set = new HashSet<InteractableSpawnCard>();
+            foreach (InteractableSpawnCard isc in interactableSpawnCards)
+            {
+                if (isc.name.ToUpper().Replace("ISC", String.Empty).Equals(name.ToUpper().Replace("ISC", string.Empty)) || isc.name.ToUpper().Replace("isc", String.Empty).Contains(name.ToUpper()))
+                {
+                    set.Add(isc);
+                }
+            }
+
+            return set.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
Modified Lists.CCList_interactables, Lists.CCListAI, Lists.CCListBody, Lists.CCListDirectorCards, Items.CCListItem, and Items.CCListEquip to accept one argument to use filter out results based on the string.
Updated Lang for the associated lists
Added StringFinder.GetEquipsFromPartial, StringFinder.GetItemsFromPartial, and StringFinder.GetInteractableSpawnCards based off their existing individual methods for use in list_equip, list_item for code clarity.

I didn't use an external method for list_body and list_ai since I was unsure of how to implement their external StringFinder methods (since their original methods returned a string). I didn't include list_player with the queries since I did not feel it as useful as the rest. I was also unsure about list_Directorcards.
![image](https://user-images.githubusercontent.com/72328339/213889205-2dbaab4f-3b88-481e-ba29-2a466a10ed53.png)
