### PR TITLE
More robust error logging

### DIFF
--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -11,7 +11,7 @@ namespace DebugToolkit.Commands
 {
     class Items
     {
-        [ConCommand(commandName = "list_item", flags = ConVarFlags.None, helpText = "List all items and their availability. "+ Lang.LISTITEM_ARGS)]
+        [ConCommand(commandName = "list_item", flags = ConVarFlags.None, helpText = Lang.LISTITEM_HELP)]
         private static void CCListItem(ConCommandArgs args)
         {
             var sb = new StringBuilder();
@@ -19,7 +19,7 @@ namespace DebugToolkit.Commands
             if (args.Count > 0)
             {
                 itemList = (IEnumerable<ItemIndex>)StringFinder.Instance.GetItemsFromPartial(args.GetArgString(0));
-                if (itemList.Count() == 0) sb.AppendLine($"No item that matches \"{args.GetArgString(0)}\".");
+                if (itemList.Count() == 0) sb.AppendLine($"No item that matches \"{args[0]}\".");
             } else
             {
                 itemList = (IEnumerable<ItemIndex>)ItemCatalog.allItems;
@@ -27,26 +27,26 @@ namespace DebugToolkit.Commands
             foreach (var itemIndex in itemList)
             {
                 var definition = ItemCatalog.GetItemDef(itemIndex);
-                string enabled = false.ToString();
+                bool enabled = false;
                 var realName = Language.currentLanguage.GetLocalizedStringByToken(definition.nameToken);
                 if (Run.instance)
                 {
-                    enabled = Run.instance.IsItemAvailable(itemIndex).ToString();
+                    enabled = Run.instance.IsItemAvailable(itemIndex);
                 }
                 sb.AppendLine($"[{(int)itemIndex}]: {definition.name} \"{realName}\" (enabled={enabled})");
             }
-            Log.Message(sb.ToString());
+            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-        [ConCommand(commandName = "list_equip", flags = ConVarFlags.None, helpText = "List all equipment and their availability. " + Lang.LISTEQUIP_ARGS)]
+        [ConCommand(commandName = "list_equip", flags = ConVarFlags.None, helpText = Lang.LISTEQUIP_HELP)]
         private static void CCListEquip(ConCommandArgs args)
         {
             var sb = new StringBuilder();
             IEnumerable<EquipmentIndex> list;
             if (args.Count > 0)
             {
-                list = StringFinder.Instance.GetEquipsFromPartial(args.GetArgString(0));
-                    if (list.Count() == 0) sb.AppendLine($"No equipment that matches \"{args.GetArgString(0)}\".");
+                list = StringFinder.Instance.GetEquipsFromPartial(args[0]);
+                if (list.Count() == 0) sb.AppendLine($"No equipment that matches \"{args[0]}\".");
             }
             else
             {
@@ -56,48 +56,42 @@ namespace DebugToolkit.Commands
             foreach (var equipmentIndex in list)
             {
                 var definition = EquipmentCatalog.GetEquipmentDef(equipmentIndex);
-                string enabled = false.ToString();
+                bool enabled = false;
                 var realName = Language.currentLanguage.GetLocalizedStringByToken(definition.nameToken);
                 if (Run.instance)
                 {
-                    enabled = Run.instance.IsEquipmentAvailable(equipmentIndex).ToString();
+                    enabled = Run.instance.IsEquipmentAvailable(equipmentIndex);
                 }
-                sb.AppendLine($"[{(int)equipmentIndex}]: {definition.name} \"{realName}\"  (enabled={enabled})");
+                sb.AppendLine($"[{(int)equipmentIndex}]: {definition.name} \"{realName}\" (enabled={enabled})");
             }
-            Log.Message(sb.ToString());
+            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-
-        [ConCommand(commandName = "give_item", flags = ConVarFlags.ExecuteOnServer, helpText = "Gives the specified item to a character. " + Lang.GIVEITEM_ARGS)]
+        [ConCommand(commandName = "give_item", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.GIVEITEM_HELP)]
         [AutoCompletion(typeof(ItemCatalog), "itemDefs", "nameToken")]
         private static void CCGiveItem(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.GIVEITEM_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            bool isDedicatedServer = args.sender == null;
+            if (args.Count == 0 || (args.Count < 3 && isDedicatedServer))
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.GIVEITEM_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
-            bool isDedicatedServer = false;
-            if (args.sender == null)
+            int iCount = 1;
+            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE && !TextSerialization.TryParseInvariant(args[1], out iCount))
             {
-                isDedicatedServer = true;
-                if (args.Count < 3)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    Log.Message(Lang.GIVEITEM_ARGS, LogLevel.Message);
-                    return;
-                }
-            }
-
-            int iCount = 1; // it'll get overwritten by the TryParse...
-            if (args.Count >= 2 && args[1] != Lang.DEFAULT_VALUE)
-            {
-                iCount = int.TryParse(args[1], out iCount) ? iCount : 1;
+                Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "count", "int"), args, LogLevel.MessageClientOnly);
+                return;
             }
 
             CharacterBody target = args.senderBody;
-            if (args.Count >= 3 && args[2] != Lang.DEFAULT_VALUE)
+            if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 2, isDedicatedServer);
             }
@@ -124,46 +118,38 @@ namespace DebugToolkit.Commands
             }
 
             var item = StringFinder.Instance.GetItemFromPartial(args[0]);
-            if (item != ItemIndex.None)
-            {
-                inventory.GiveItem(item, iCount);
-                Log.MessageNetworked($"Gave {iCount} {item} to {targetName}", args);
-            }
-            else
+            if (item == ItemIndex.None)
             {
                 Log.MessageNetworked(Lang.OBJECT_NOTFOUND + args[0] + ":" + item, args, LogLevel.MessageClientOnly);
+                return;
             }
+            inventory.GiveItem(item, iCount);
+            Log.MessageNetworked($"Gave {iCount} {item} to {targetName}", args);
         }
 
-        [ConCommand(commandName = "random_items", flags = ConVarFlags.ExecuteOnServer, helpText = "Generates the specified amount of items for a character from the available item pools at random.")]
-        private static void CCRandom_items(ConCommandArgs args)
+        [ConCommand(commandName = "random_items", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.RANDOMITEM_HELP)]
+        private static void CCRandomItems(ConCommandArgs args)
         {
-            bool isDedicatedServer = false;
-            if (args.sender == null)
+            if (!Run.instance)
             {
-                isDedicatedServer = true;
-                if (args.Count < 2)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    Log.Message(Lang.RANDOM_ITEM_ARGS, LogLevel.Message);
-                    return;
-                }
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
             }
-
-            if (args.Count < 1)
+            bool isDedicatedServer = args.sender == null;
+            if (args.Count == 0 || (args.Count < 2 && isDedicatedServer))
             {
-                Log.MessageNetworked(Lang.RANDOM_ITEM_ARGS, args);
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.RANDOMITEM_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
             CharacterBody target = args.senderBody;
-            if (args.Count >= 2 && args[1] != Lang.DEFAULT_VALUE)
+            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[1] == Lang.PINGED.ToUpper())
+                if (!isDedicatedServer && args[1].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                 }
@@ -183,43 +169,40 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            var a = args.TryGetArgInt(0);
-            if (a.HasValue && a.Value > 0)
+            if (!TextSerialization.TryParseInvariant(args[0], out int iCount))
             {
-                inventory.GiveRandomItems(a.Value, false, false);
-                Log.MessageNetworked($"Generated {a.Value} items for {targetName}!", args);
+                Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "count", "int"), args, LogLevel.MessageClientOnly);
+                return;
+            }
+            if (iCount > 0)
+            {
+                inventory.GiveRandomItems(iCount, false, false);
+                Log.MessageNetworked($"Generated {iCount} items for {targetName}!", args);
             }
             else
             {
-                Log.MessageNetworked(Lang.RANDOM_ITEM_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked("'count' should be a non-zero positive integer.", args, LogLevel.MessageClientOnly);
             }
-
         }
 
-        [ConCommand(commandName = "give_equip", flags = ConVarFlags.ExecuteOnServer, helpText = "Gives the specified equipment to a character. " + Lang.GIVEEQUIP_ARGS)]
+        [ConCommand(commandName = "give_equip", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.GIVEEQUIP_HELP)]
         [AutoCompletion(typeof(EquipmentCatalog), "equipmentDefs", "nameToken")]
         private static void CCGiveEquipment(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.GIVEEQUIP_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            bool isDedicatedServer = args.sender == null;
+            if (args.Count == 0 || (args.Count < 2 && isDedicatedServer))
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.GIVEEQUIP_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
-            bool isDedicatedServer = false;
-            if (args.sender == null)
-            {
-                isDedicatedServer = true;
-                if (args.Count < 2)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    Log.Message(Lang.GIVEEQUIP_ARGS, LogLevel.Message);
-                    return;
-                }
-            }
-
             CharacterBody target = args.senderBody;
-            if (args.Count >= 2 && args[1] != Lang.DEFAULT_VALUE)
+            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
             }
@@ -250,7 +233,7 @@ namespace DebugToolkit.Commands
             {
                 inventory.SetEquipmentIndex(equip);
             }
-            else if (args[0].ToLower() == "random")
+            else if (args[0].ToUpper() == Lang.RANDOM)
             {
                 inventory.GiveRandomEquipment();
                 equip = inventory.GetEquipmentIndex();
@@ -264,20 +247,26 @@ namespace DebugToolkit.Commands
             Log.MessageNetworked($"Gave {equip} to {targetName}", args);
         }
 
-        [ConCommand(commandName = "give_lunar", flags = ConVarFlags.ExecuteOnServer, helpText = "Gives a lunar coin to you. " + Lang.GIVELUNAR_ARGS)]
+        [ConCommand(commandName = "give_lunar", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.GIVELUNAR_HELP)]
         private static void CCGiveLunar(ConCommandArgs args)
         {
+            if (!Run.instance)
+            {
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
             if (args.sender == null)
             {
-                Log.Message("Can't modify Lunar coins of other users directly.", LogLevel.Error);
+                Log.Message("Can't modify Lunar coins of other users directly.", LogLevel.MessageClientOnly);
                 return;
             }
             int amount = 1;
-            if (args.Count > 0)
+            if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE && !TextSerialization.TryParseInvariant(args[0], out amount))
             {
-                amount = args.GetArgInt(0);
+                Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "amount", "int"), args, LogLevel.MessageClientOnly);
+                return;
             }
-            string str = "Nothing happened. Big suprise.";
+            string str = "Nothing happened. Big surprise.";
             NetworkUser target = RoR2.Util.LookUpBodyNetworkUser(args.senderBody);
             if (amount > 0)
             {
@@ -293,44 +282,45 @@ namespace DebugToolkit.Commands
             Log.MessageNetworked(str, args);
         }
 
-        [ConCommand(commandName = "create_pickup", flags = ConVarFlags.ExecuteOnServer, helpText = "Creates a PickupDroplet infront of your position. " + Lang.CREATEPICKUP_ARGS)]
+        [ConCommand(commandName = "create_pickup", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.CREATEPICKUP_HELP)]
         private static void CCCreatePickup(ConCommandArgs args)
         {
-            args.CheckArgumentCount(1);
-            if (args.sender == null)
+            if (!Run.instance)
             {
-                if (args.Count <= 3)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    return;
-                }
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            if (args.Count == 0 || (args.Count < 3 && args.sender == null))
+            {
+                Log.Message(Lang.INSUFFICIENT_ARGS + Lang.CREATEPICKUP_ARGS, LogLevel.MessageClientOnly);
+                return;
             }
             NetworkUser player = args.sender;
-            if (args.Count >= 3)
+            if (args.Count > 2)
             {
                 player = Util.GetNetUserFromString(args.userArgs, 2);
                 if (player == null)
                 {
-                    Log.Message(Lang.PLAYER_NOTFOUND, LogLevel.MessageClientOnly);
-                    if (args.sender == null)
-                    {
-                        return;
-                    }
-                    player = args.sender;
+                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
                 }
             }
             Transform transform = player.GetCurrentBody().gameObject.transform;
 
             bool searchEquip = true, searchItem = true;
-            if (args.Count == 2)
+            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
-                if (args[1].Equals("item", StringComparison.OrdinalIgnoreCase))
+                switch (args[1].ToUpper())
                 {
-                    searchEquip = false;
-                }
-                if (args[1].ToUpper().StartsWith("EQUIP"))
-                {
-                    searchItem = false;
+                    case Lang.ITEM:
+                        searchEquip = false;
+                        break;
+                    case Lang.EQUIP:
+                        searchItem = false;
+                        break;
+                    default:
+                        Log.MessageNetworked(String.Format(Lang.INVALID_ARG_VALUE, "search"), args, LogLevel.MessageClientOnly);
+                        return;
                 }
             }
             PickupIndex final = PickupIndex.none;
@@ -355,7 +345,7 @@ namespace DebugToolkit.Commands
 
             if (item == ItemIndex.None && equipment == EquipmentIndex.None)
             {
-                if (args[0].ToUpper().Contains("COIN"))
+                if (args[0].ToUpper() == Lang.COIN)
                 {
                     final = PickupCatalog.FindPickupIndex("LunarCoin.Coin0");
                 }
@@ -369,34 +359,30 @@ namespace DebugToolkit.Commands
             PickupDropletController.CreatePickupDroplet(final, transform.position, transform.forward * 40f);
         }
 
-        [ConCommand(commandName = "remove_item", flags = ConVarFlags.ExecuteOnServer, helpText = "Removes the specified quantities of an item from a character. " + Lang.REMOVEITEM_ARGS)]
+        [ConCommand(commandName = "remove_item", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.REMOVEITEM_HELP)]
         private static void CCRemoveItem(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.REMOVEITEM_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            bool isDedicatedServer = args.sender == null;
+            if (args.Count == 0 || (args.Count < 3 && isDedicatedServer))
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.REMOVEITEM_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
-            bool isDedicatedServer = false;
-            if (args.sender == null)
-            {
-                isDedicatedServer = true;
-                if (args.Count < 3)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    return;
-                }
-            }
-
             int iCount = 1;
-            if (args.Count >= 2)
+            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE && !TextSerialization.TryParseInvariant(args[1], out iCount))
             {
-                iCount = int.TryParse(args[1], out iCount) ? iCount : 1;
+                Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "count", "int"), args, LogLevel.MessageClientOnly);
+                return;
             }
 
             CharacterBody target = args.senderBody;
-            if (args.Count >= 3 && args[2] != Lang.DEFAULT_VALUE)
+            if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 2, isDedicatedServer);
             }
@@ -423,39 +409,32 @@ namespace DebugToolkit.Commands
             }
 
             var item = StringFinder.Instance.GetItemFromPartial(args[0]);
-            if (item != ItemIndex.None)
-            {
-                inventory.RemoveItem(item, iCount);
-                Log.MessageNetworked($"Removed {iCount} {item} from {targetName}", args);
-            }
-            else
+            if (item == ItemIndex.None)
             {
                 Log.MessageNetworked(Lang.OBJECT_NOTFOUND + args[0] + ":" + item, args, LogLevel.MessageClientOnly);
+                return;
             }
+            inventory.RemoveItem(item, iCount);
+            Log.MessageNetworked($"Removed {iCount} {item} from {targetName}", args);
         }
 
-        [ConCommand(commandName = "remove_item_stacks", flags = ConVarFlags.ExecuteOnServer, helpText = "Removes all the stacks of a specified item from a character. " + Lang.REMOVEITEMSTACKS_ARGS)]
+        [ConCommand(commandName = "remove_item_stacks", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.REMOVEITEMSTACKS_HELP)]
         private static void CCRemoveItemStacks(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.REMOVEITEMSTACKS_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            bool isDedicatedServer = false;
+            if (args.Count == 0 || (args.Count < 2 && isDedicatedServer))
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.REMOVEITEMSTACKS_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
-            bool isDedicatedServer = false;
-            if (args.sender == null)
-            {
-                isDedicatedServer = true;
-                if (args.Count < 2)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    return;
-                }
-            }
-
             CharacterBody target = args.senderBody;
-            if (args.Count >= 2 && args[1] != Lang.DEFAULT_VALUE)
+            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
             }
@@ -482,34 +461,33 @@ namespace DebugToolkit.Commands
             }
 
             var item = StringFinder.Instance.GetItemFromPartial(args[0]);
-            if (item != ItemIndex.None)
-            {
-                int iCount = inventory.GetItemCount(item);
-                inventory.RemoveItem(item, iCount);
-                Log.MessageNetworked($"Removed {iCount} {item} from {targetName}", args);
-            }
-            else
+            if (item == ItemIndex.None)
             {
                 Log.MessageNetworked(Lang.OBJECT_NOTFOUND + args[0] + ":" + item, args, LogLevel.MessageClientOnly);
+                return;
             }
+            int iCount = inventory.GetItemCount(item);
+            inventory.RemoveItem(item, iCount);
+            Log.MessageNetworked($"Removed {iCount} {item} from {targetName}", args);
         }
 
-        [ConCommand(commandName = "remove_all_items", flags = ConVarFlags.ExecuteOnServer, helpText = "Removes all items from a character. " + Lang.REMOVEALLITEMS_ARGS)]
+        [ConCommand(commandName = "remove_all_items", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.REMOVEALLITEMS_HELP)]
         private static void CCRemoveAllItems(ConCommandArgs args)
         {
-            bool isDedicatedServer = false;
-            if (args.sender == null)
+            if (!Run.instance)
             {
-                isDedicatedServer = true;
-                if (args.Count < 1)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    return;
-                }
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            bool isDedicatedServer = args.sender == null;
+            if (args.Count < 1 && isDedicatedServer)
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.REMOVEALLITEMS_ARGS, args,LogLevel.MessageClientOnly);
+                return;
             }
 
             CharacterBody target = args.senderBody;
-            if (args.Count >= 1 && args[0] != Lang.DEFAULT_VALUE)
+            if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 0, isDedicatedServer);
             }
@@ -541,22 +519,23 @@ namespace DebugToolkit.Commands
             Log.MessageNetworked($"Reseting inventory for {targetName}", args);
         }
 
-        [ConCommand(commandName = "remove_equip", flags = ConVarFlags.ExecuteOnServer, helpText = "Removes the equipment from a character. " + Lang.REMOVEEQUIP_ARGS)]
+        [ConCommand(commandName = "remove_equip", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.REMOVEEQUIP_HELP)]
         private static void CCRemoveEquipment(ConCommandArgs args)
         {
-            bool isDedicatedServer = false;
-            if (args.sender == null)
+            if (!Run.instance)
             {
-                isDedicatedServer = true;
-                if (args.Count < 1)
-                {
-                    Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                    return;
-                }
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            bool isDedicatedServer = args.sender == null;
+            if (args.Count < 1 && isDedicatedServer)
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.REMOVEEQUIP_ARGS, args, LogLevel.MessageClientOnly);
+                return;
             }
 
             CharacterBody target = args.senderBody;
-            if (args.Count >= 1 && args[0] != Lang.DEFAULT_VALUE)
+            if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 0, isDedicatedServer);
             }
@@ -583,7 +562,6 @@ namespace DebugToolkit.Commands
             }
 
             inventory.SetEquipmentIndex(EquipmentIndex.None);
-
             Log.MessageNetworked($"Removed current Equipment from {targetName}", args);
         }
     }

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -94,17 +94,15 @@ namespace DebugToolkit.Commands
             if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 2, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[2] == Lang.PINGED)
+                {
+                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[2].ToUpper() == Lang.PINGED)
-                {
-                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
@@ -146,17 +144,15 @@ namespace DebugToolkit.Commands
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[1] == Lang.PINGED)
+                {
+                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[1].ToUpper() == Lang.PINGED)
-                {
-                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
@@ -205,17 +201,15 @@ namespace DebugToolkit.Commands
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[1] == Lang.PINGED)
+                {
+                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[1].ToUpper() == Lang.PINGED)
-                {
-                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
@@ -385,17 +379,15 @@ namespace DebugToolkit.Commands
             if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 2, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[2] == Lang.PINGED)
+                {
+                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[2].ToUpper() == Lang.PINGED)
-                {
-                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
@@ -437,17 +429,15 @@ namespace DebugToolkit.Commands
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[1] == Lang.PINGED)
+                {
+                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[1].ToUpper() == Lang.PINGED)
-                {
-                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
@@ -490,17 +480,15 @@ namespace DebugToolkit.Commands
             if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 0, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[0] == Lang.PINGED)
+                {
+                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[0].ToUpper() == Lang.PINGED)
-                {
-                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
@@ -538,17 +526,15 @@ namespace DebugToolkit.Commands
             if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
                 target = Util.GetBodyFromArgs(args.userArgs, 0, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[0] == Lang.PINGED)
+                {
+                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
             if (target == null)
             {
-                if (!isDedicatedServer && args[0].ToUpper() == Lang.PINGED)
-                {
-                    Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                }
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -90,11 +90,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            CharacterBody target = args.senderBody;
+            CharacterMaster target = args.senderMaster;
             if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetBodyFromArgs(args.userArgs, 2, isDedicatedServer);
-                if (target == null && !isDedicatedServer && args[2] == Lang.PINGED)
+                target = Util.GetTargetFromArgs(args.userArgs, 2, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[2].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -105,7 +105,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
+            NetworkUser player = target.playerCharacterMasterController?.networkUser;
             string targetName = (player != null) ? player.masterController.GetDisplayName() : target.gameObject.name;
 
             Inventory inventory = target.inventory;
@@ -140,11 +140,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            CharacterBody target = args.senderBody;
+            CharacterMaster target = args.senderMaster;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
-                if (target == null && !isDedicatedServer && args[1] == Lang.PINGED)
+                target = Util.GetTargetFromArgs(args.userArgs, 1, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[1].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -155,7 +155,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
+            NetworkUser player = target.playerCharacterMasterController?.networkUser;
             string targetName = (player != null) ? player.masterController.GetDisplayName() : target.gameObject.name;
 
             Inventory inventory = target.inventory;
@@ -197,11 +197,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            CharacterBody target = args.senderBody;
+            CharacterMaster target = args.senderMaster;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
-                if (target == null && !isDedicatedServer && args[1] == Lang.PINGED)
+                target = Util.GetTargetFromArgs(args.userArgs, 1, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[1].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -212,7 +212,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
+            NetworkUser player = target.playerCharacterMasterController?.networkUser;
             string targetName = (player != null) ? player.masterController.GetDisplayName() : target.gameObject.name;
 
             Inventory inventory = target.inventory;
@@ -261,7 +261,7 @@ namespace DebugToolkit.Commands
                 return;
             }
             string str = "Nothing happened. Big surprise.";
-            NetworkUser target = RoR2.Util.LookUpBodyNetworkUser(args.senderBody);
+            NetworkUser target = args.sender;
             if (amount > 0)
             {
                 target.AwardLunarCoins((uint)amount);
@@ -299,7 +299,13 @@ namespace DebugToolkit.Commands
                     return;
                 }
             }
-            Transform transform = player.GetCurrentBody().gameObject.transform;
+            Transform transform = player.GetCurrentBody()?.gameObject.transform;
+            if (transform == null)
+            {
+                // We could possibly use `player.master.deathFootPosition` instead
+                Log.MessageNetworked("Can't spawn an object with relation to a dead player.", args, LogLevel.MessageClientOnly);
+                return;
+            }
 
             bool searchEquip = true, searchItem = true;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
@@ -375,11 +381,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            CharacterBody target = args.senderBody;
+            CharacterMaster target = args.senderMaster;
             if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetBodyFromArgs(args.userArgs, 2, isDedicatedServer);
-                if (target == null && !isDedicatedServer && args[2] == Lang.PINGED)
+                target = Util.GetTargetFromArgs(args.userArgs, 2, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[2].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -390,7 +396,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
+            NetworkUser player = target.playerCharacterMasterController?.networkUser;
             string targetName = (player != null) ? player.masterController.GetDisplayName() : target.gameObject.name;
 
             Inventory inventory = target.inventory;
@@ -425,11 +431,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            CharacterBody target = args.senderBody;
+            CharacterMaster target = args.senderMaster;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetBodyFromArgs(args.userArgs, 1, isDedicatedServer);
-                if (target == null && !isDedicatedServer && args[1] == Lang.PINGED)
+                target = Util.GetTargetFromArgs(args.userArgs, 1, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[1].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -440,7 +446,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
+            NetworkUser player = target.playerCharacterMasterController?.networkUser;
             string targetName = (player != null) ? player.masterController.GetDisplayName() : target.gameObject.name;
 
             Inventory inventory = target.inventory;
@@ -476,11 +482,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            CharacterBody target = args.senderBody;
+            CharacterMaster target = args.senderMaster;
             if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetBodyFromArgs(args.userArgs, 0, isDedicatedServer);
-                if (target == null && !isDedicatedServer && args[0] == Lang.PINGED)
+                target = Util.GetTargetFromArgs(args.userArgs, 0, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[0].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -491,7 +497,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
+            NetworkUser player = target.playerCharacterMasterController?.networkUser;
             string targetName = (player != null) ? player.masterController.GetDisplayName() : target.gameObject.name;
 
             Inventory inventory = target.inventory;
@@ -522,11 +528,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            CharacterBody target = args.senderBody;
+            CharacterMaster target = args.senderMaster;
             if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetBodyFromArgs(args.userArgs, 0, isDedicatedServer);
-                if (target == null && !isDedicatedServer && args[0] == Lang.PINGED)
+                target = Util.GetTargetFromArgs(args.userArgs, 0, isDedicatedServer);
+                if (target == null && !isDedicatedServer && args[0].ToUpper() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -537,7 +543,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            NetworkUser player = RoR2.Util.LookUpBodyNetworkUser(target);
+            NetworkUser player = target.playerCharacterMasterController?.networkUser;
             string targetName = (player != null) ? player.masterController.GetDisplayName() : target.gameObject.name;
 
             Inventory inventory = target.inventory;

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -12,18 +12,18 @@ namespace DebugToolkit.Commands
 {
     class Lists
     {
-        [ConCommand(commandName = "list_interactables", flags = ConVarFlags.None, helpText = Lang.LISTINTERACTABLE_ARGS)]
-        private static void CCList_interactables(ConCommandArgs args)
+        [ConCommand(commandName = "list_interactables", flags = ConVarFlags.None, helpText = Lang.LISTINTERACTABLE_HELP)]
+        private static void CCListInteractables(ConCommandArgs args)
         {
             //edits based on StringFinder.GetInteractableSpawnCard()
             StringBuilder s = new StringBuilder();
             IEnumerable<InteractableSpawnCard> list;
             if (args.Count > 0)
             {
-                list = StringFinder.Instance.GetInteractableSpawnCards(args.GetArgString(0));
+                list = StringFinder.Instance.GetInteractableSpawnCards(args[0]);
 
                 if (list.Count() == 0)
-                    s.AppendLine($"No interactables found that match \"{args.GetArgString(0)}\".");
+                    s.AppendLine($"No interactables found that match \"{args[0]}\".");
             } else
             {
                 list = StringFinder.Instance.InteractableSpawnCards;
@@ -33,10 +33,10 @@ namespace DebugToolkit.Commands
             {
                 s.AppendLine(isc.name.Replace("isc", string.Empty));
             }
-            Log.Message(s.ToString(), LogLevel.MessageClientOnly);
+            Log.MessageNetworked(s.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-        [ConCommand(commandName = "list_player", flags = ConVarFlags.None, helpText = Lang.LISTPLAYER_ARGS)]
+        [ConCommand(commandName = "list_player", flags = ConVarFlags.None, helpText = Lang.LISTPLAYER_HELP)]
         private static void CCListPlayer(ConCommandArgs args)
         {
             StringBuilder sb = new StringBuilder();
@@ -73,7 +73,7 @@ namespace DebugToolkit.Commands
             Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-        [ConCommand(commandName = "list_ai", flags = ConVarFlags.None, helpText = Lang.LISTAI_ARGS)]
+        [ConCommand(commandName = "list_ai", flags = ConVarFlags.None, helpText = Lang.LISTAI_HELP)]
         private static void CCListAI(ConCommandArgs args)
         {
             string langInvar;
@@ -82,7 +82,7 @@ namespace DebugToolkit.Commands
             int resultCount = 0;
             if (args.Count > 0)
             {
-                string name = args.GetArgString(0);
+                string name = args[0];
                 foreach (var master in MasterCatalog.allAiMasters)
                 {
                     var masterName = master.name.ToUpper();
@@ -107,11 +107,10 @@ namespace DebugToolkit.Commands
                     i++;
                 }
             }
-            Log.Message(sb);
-
+            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-        [ConCommand(commandName = "list_body", flags = ConVarFlags.None, helpText = Lang.LISTBODY_ARGS)]
+        [ConCommand(commandName = "list_body", flags = ConVarFlags.None, helpText = Lang.LISTBODY_HELP)]
         private static void CCListBody(ConCommandArgs args)
         {
             StringBuilder sb = new StringBuilder();
@@ -121,7 +120,7 @@ namespace DebugToolkit.Commands
 
             if (args.Count > 0)
             {
-                string name = args.GetArgString(0);
+                string name = args[0];
                 foreach (var body in BodyCatalog.allBodyPrefabBodyBodyComponents)
                 {
                     var upperBodyName = body.name.ToUpper();
@@ -147,10 +146,10 @@ namespace DebugToolkit.Commands
                     i++;
                 }
             }
-            Log.Message(sb);
+            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-        [ConCommand(commandName = "list_elite", flags = ConVarFlags.None, helpText = Lang.LISTELITE_ARGS)]
+        [ConCommand(commandName = "list_elite", flags = ConVarFlags.None, helpText = Lang.LISTELITE_HELP)]
         private static void CCListElites(ConCommandArgs args)
         {
             StringBuilder sb = new StringBuilder();
@@ -159,7 +158,7 @@ namespace DebugToolkit.Commands
 
             if (args.Count > 0)
             {
-                string name = args.GetArgString(0);
+                string name = args[0];
                 if (int.TryParse(name, out int iName) && iName == -1 || "NONE".Contains(name.ToUpper()))
                 {
                     sb.AppendLine("[-1]None");
@@ -193,7 +192,7 @@ namespace DebugToolkit.Commands
             Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-        [ConCommand(commandName = "list_team", flags = ConVarFlags.None, helpText = Lang.LISTTEAM_ARGS)]
+        [ConCommand(commandName = "list_team", flags = ConVarFlags.None, helpText = Lang.LISTTEAM_HELP)]
         private static void CCListTeams(ConCommandArgs args)
         {
             StringBuilder sb = new StringBuilder();
@@ -233,21 +232,21 @@ namespace DebugToolkit.Commands
                     i++;
                 }
             }
-            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
+            Log.Message(sb);
         }
 
-        [ConCommand(commandName = "list_directorcards", flags = ConVarFlags.None, helpText = Lang.NOMESSAGE)]
-        private static void CCListDirectorCards(ConCommandArgs _)
+        [ConCommand(commandName = "list_directorcards", flags = ConVarFlags.None, helpText = Lang.LISTDIRECTORCARDS_HELP)]
+        private static void CCListDirectorCards(ConCommandArgs args)
         {
             StringBuilder sb = new StringBuilder();
             foreach (var card in StringFinder.Instance.DirectorCards)
             {
                 sb.AppendLine($"{card.spawnCard.name}");
             }
-            Log.Message(sb);
+            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
-        [ConCommand(commandName = "list_skin", flags = ConVarFlags.None, helpText = Lang.LISTSKIN_ARGS)]
+        [ConCommand(commandName = "list_skin", flags = ConVarFlags.None, helpText = Lang.LISTSKIN_HELP)]
         private static void CCListSkin(ConCommandArgs args)
         {
             //string langInvar;
@@ -258,7 +257,7 @@ namespace DebugToolkit.Commands
             }
             if (args.Count >= 1)
             {
-                string bodyName = args.GetArgString(0);
+                string bodyName = args[0];
                 string upperBodyName = bodyName.ToUpperInvariant();
 
                 switch (upperBodyName)
@@ -330,7 +329,7 @@ namespace DebugToolkit.Commands
                 }
             }
 
-            Log.Message(sb);
+            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
         }
 
         private static void AppendSkinIndices(StringBuilder stringBuilder, CharacterBody body)

--- a/Code/DT-Commands/Macros.cs
+++ b/Code/DT-Commands/Macros.cs
@@ -4,7 +4,7 @@ namespace DebugToolkit.Commands
 {
     static class Macros
     {
-        [ConCommand(commandName = "midgame", flags = ConVarFlags.ExecuteOnServer, helpText = "sets the current run to the 'midgame' as defined by HG. This command is DESTRUCTIVE.")]
+        [ConCommand(commandName = "midgame", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.MACRO_MIDGAME_HELP)]
         private static void Midgame(ConCommandArgs args)
         {
             NetworkUser a = args.sender;
@@ -20,7 +20,7 @@ namespace DebugToolkit.Commands
             Invoke(a, "set_scene", "bazaar");
         }
 
-        [ConCommand(commandName = "lategame", flags = ConVarFlags.ExecuteOnServer, helpText = "sets the current run to the 'lategame' as defined by HG. This command is DESTRUCTIVE.")]
+        [ConCommand(commandName = "lategame", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.MACRO_LATEGAME_HELP)]
         private static void LateGame(ConCommandArgs args)
         {
             NetworkUser a = args.sender;
@@ -36,7 +36,7 @@ namespace DebugToolkit.Commands
             Invoke(a, "set_scene", "bazaar");
         }
 
-        [ConCommand(commandName = "dtzoom", flags = ConVarFlags.ExecuteOnServer, helpText = "gives you 20 hooves and 200 feathers for getting around quickly.")]
+        [ConCommand(commandName = "dtzoom", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.MACRO_DTZOOM_HELP)]
         private static void Zoom(ConCommandArgs args)
         {
             Invoke(args.sender, "give_item", "hoof", "20");

--- a/Code/DT-Commands/Miscellaneous.cs
+++ b/Code/DT-Commands/Miscellaneous.cs
@@ -5,7 +5,7 @@ namespace DebugToolkit.Commands
 {
     class Miscellaneous
     {
-        [ConCommand(commandName = "post_sound_event", flags = ConVarFlags.ExecuteOnServer, helpText = "Post a sound event to the AkSoundEngine (WWise) by its event name.")]
+        [ConCommand(commandName = "post_sound_event", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.POSTSOUNDEVENT_HELP)]
         private static void CCPostSoundEvent(ConCommandArgs args)
         {
             if (args.sender == null)
@@ -13,25 +13,29 @@ namespace DebugToolkit.Commands
                 Log.MessageWarning(Lang.DS_NOTAVAILABLE);
                 return;
             }
+            if (args.Count == 0)
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.POSTSOUNDEVENT_ARGS, args, Log.LogLevel.MessageClientOnly);
+                return;
+            }
             AkSoundEngine.PostEvent(args[0], CameraRigController.readOnlyInstancesList[0].localUserViewer.currentNetworkUser.master.GetBodyObject());
         }
 
-        [ConCommand(commandName = "reload_all_config", flags = ConVarFlags.None, helpText = "Reload all default config files from all loaded plugins.")]
-        private static void CCReloadAllConfig(ConCommandArgs _)
+        [ConCommand(commandName = "reload_all_config", flags = ConVarFlags.None, helpText = Lang.RELOADCONFIG_HELP)]
+        private static void CCReloadAllConfig(ConCommandArgs args)
         {
             foreach (var pluginInfo in Chainloader.PluginInfos.Values)
             {
                 try
                 {
+                    // Will this even fail with the null conditional operator?
                     pluginInfo.Instance.Config?.Reload();
                 }
                 catch
                 {
-                    // exception if the config file of that plugin doesnt exist. Also, can't reload a plugins config if it has a custom name. 
+                    Log.MessageNetworked($"The config file for {pluginInfo} doesn't exist or has a custom name.", args, Log.LogLevel.Warning);
                 }
             }
         }
-
-
     }
 }

--- a/Code/DT-Commands/Money.cs
+++ b/Code/DT-Commands/Money.cs
@@ -6,17 +6,23 @@ namespace DebugToolkit.Commands
 {
     class Money
     {
-        [ConCommand(commandName = "give_money", flags = ConVarFlags.ExecuteOnServer, helpText = "Gives the specified amount of money to the specified player. " + Lang.GIVEMONEY_ARGS)]
+        [ConCommand(commandName = "give_money", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.GIVEMONEY_HELP)]
         private static void CCGiveMoney(ConCommandArgs args)
         {
+            if (!Run.instance)
+            {
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
             if (args.Count == 0)
             {
-                Log.MessageNetworked(Lang.GIVEMONEY_ARGS, args, LogLevel.WarningClientOnly);
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.GIVEMONEY_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
             if (!TextSerialization.TryParseInvariant(args[0], out uint result))
             {
+                Log.MessageNetworked(string.Format(Lang.PARSE_ERROR, "amount", "uint"), args, LogLevel.MessageClientOnly);
                 return;
             }
 
@@ -28,7 +34,7 @@ namespace DebugToolkit.Commands
                 }
             }
 
-            if (args.sender != null && args.Count < 2 || args[1].ToLower() != "all")
+            if (args.sender != null && args.Count < 2 || args[1].ToUpper() != Lang.ALL || args[1].ToUpper() != Lang.DEFAULT_VALUE)
             {
                 CharacterMaster master = args.sender?.master;
                 if (args.Count >= 2)
@@ -79,9 +85,7 @@ namespace DebugToolkit.Commands
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         private static bool UseShareSuite()
         {
-            if (ShareSuite.ShareSuite.MoneyIsShared.Value)
-                return true;
-            return false;
+            return ShareSuite.ShareSuite.MoneyIsShared.Value;
         }
     }
 }

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -7,9 +7,14 @@ namespace DebugToolkit.Commands
 {
     class PlayerCommands
     {
-        [ConCommand(commandName = "god", flags = ConVarFlags.ExecuteOnServer, helpText = "Become invincible. " + Lang.GOD_ARGS)]
+        [ConCommand(commandName = "god", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.GOD_HELP)]
         private static void CCGodModeToggle(ConCommandArgs args)
         {
+            if (!Run.instance)
+            {
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
             bool hasNotYetRun = true;
             foreach (var playerInstance in PlayerCharacterMasterController.instances)
             {
@@ -22,7 +27,7 @@ namespace DebugToolkit.Commands
             }
         }
 
-        [ConCommand(commandName = "noclip", flags = ConVarFlags.ExecuteOnServer, helpText = "Allow flying and going through objects. Sprinting will double the speed. " + Lang.NOCLIP_ARGS)]
+        [ConCommand(commandName = "noclip", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.NOCLIP_HELP)]
         private static void CCNoclip(ConCommandArgs args)
         {
             if (args.sender == null)
@@ -30,17 +35,15 @@ namespace DebugToolkit.Commands
                 Log.MessageWarning(Lang.DS_NOTAVAILABLE);
                 return;
             }
-            if (Run.instance)
-            {
-                NoclipNet.Invoke(args.sender); // callback
-            }
-            else
+            if (!Run.instance)
             {
                 Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
             }
+            NoclipNet.Invoke(args.sender); // callback
         }
 
-        [ConCommand(commandName = "teleport_on_cursor", flags = ConVarFlags.ExecuteOnServer, helpText = "Teleport you to where your cursor is currently aiming at. " + Lang.CURSORTELEPORT_ARGS)]
+        [ConCommand(commandName = "teleport_on_cursor", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.CURSORTELEPORT_HELP)]
         private static void CCCursorTeleport(ConCommandArgs args)
         {
             if (args.sender == null)
@@ -48,53 +51,47 @@ namespace DebugToolkit.Commands
                 Log.MessageWarning(Lang.DS_NOTAVAILABLE);
                 return;
             }
-            if (Run.instance && args.senderBody)
-            {
-                TeleportNet.Invoke(args.sender); // callback
-            }
-            else
+            if (!Run.instance)
             {
                 Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
             }
+            TeleportNet.Invoke(args.sender); // callback
         }
 
-        [ConCommand(commandName = "spawn_as", flags = ConVarFlags.ExecuteOnServer, helpText = "Respawn the specified player using the specified body prefab. " + Lang.SPAWNAS_ARGS)]
+        [ConCommand(commandName = "spawn_as", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.SPAWNAS_HELP)]
         [AutoCompletion(typeof(BodyCatalog), "bodyPrefabBodyComponents", "baseNameToken")]
         private static void CCSpawnAs(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.SPAWNAS_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
+            if (args.Count == 0 || (args.Count < 2 && args.sender == null))
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.SPAWNAS_ARGS, args, LogLevel.MessageClientOnly);
+                return;
+            }
+
             string character = StringFinder.Instance.GetBodyName(args[0]);
             if (character == null)
             {
-                Log.MessageNetworked(Lang.SPAWN_ERROR + args[0], args, LogLevel.MessageClientOnly);
-                Log.MessageNetworked("Please use list_body to print CharacterBodies", args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.BODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
             GameObject newBody = BodyCatalog.FindBodyPrefab(character);
 
-            if (args.sender == null && args.Count < 2)
-            {
-                Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
-                return;
-            }
-
-            CharacterMaster master = args.sender.master;
+            CharacterMaster master = args.senderMaster;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 NetworkUser player = Util.GetNetUserFromString(args.userArgs, 1);
-                if (player != null)
-                {
-                    master = player.master;
-                }
-                else
+                if (player == null)
                 {
                     Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
                 }
+                master = player.master;
             }
 
             master.bodyPrefab = newBody;
@@ -102,8 +99,7 @@ namespace DebugToolkit.Commands
 
             if (!master.GetBody())
             {
-                Log.MessageNetworked(Lang.PLAYER_DEADRESPAWN, args, LogLevel.MessageClientOnly);
-                return;
+                Log.MessageNetworked(Lang.PLAYER_DEADRESPAWN, args);
             }
 
             RoR2.ConVar.BoolConVar stage1pod = Stage.stage1PodConVar;
@@ -113,31 +109,31 @@ namespace DebugToolkit.Commands
             stage1pod.SetBool(oldVal);
         }
 
-
-
-        [ConCommand(commandName = "respawn", flags = ConVarFlags.ExecuteOnServer, helpText = "Respawns the specified player. " + Lang.RESPAWN_ARGS)]
+        [ConCommand(commandName = "respawn", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.RESPAWN_HELP)]
         [AutoCompletion(typeof(NetworkUser), "instancesList", "userName", true)]
         //[AutoCompletion(typeof(NetworkUser), "instancesList", "_id/value", true)] // ideathhd : breaks the whole console for me
-        private static void RespawnPlayer(ConCommandArgs args)
+        private static void CCRespawnPlayer(ConCommandArgs args)
         {
-            if (args.sender == null && args.Count < 1)
+            if (!Run.instance)
             {
-                Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
-            CharacterMaster master = args.sender.master;
+            if (args.sender == null && args.Count < 1)
+            {
+                Log.Message(Lang.INSUFFICIENT_ARGS + Lang.RESPAWN_ARGS, LogLevel.Error);
+                return;
+            }
+            CharacterMaster master = args.senderMaster;
             if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
                 NetworkUser player = Util.GetNetUserFromString(args.userArgs);
-                if (player != null)
-                {
-                    master = player.master;
-                }
-                else
+                if (player == null)
                 {
                     Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
                 }
+                master = player.master;
             }
 
             Transform spawnPoint = Stage.instance.GetPlayerSpawnTransform();
@@ -145,108 +141,100 @@ namespace DebugToolkit.Commands
             Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_1, master.name), args);
         }
 
-        [ConCommand(commandName = "change_team", flags = ConVarFlags.ExecuteOnServer, helpText = "Change the specified player to the specified team. " + Lang.CHANGETEAM_ARGS)]
+        [ConCommand(commandName = "change_team", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.CHANGETEAM_HELP)]
         private static void CCChangeTeam(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.CHANGETEAM_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
-            if (args.sender == null && args.Count < 2)
+            if (args.Count == 0 || (args.Count < 2 && args.sender == null))
             {
-                Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.CHANGETEAM_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
-            CharacterMaster master = args.sender.master;
+            CharacterMaster master = args.sender?.master;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
                 NetworkUser player = Util.GetNetUserFromString(args.userArgs, 1);
-                if (player != null)
-                {
-                    master = player.master;
-                }
-                else
+                if (player == null)
                 {
                     Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
                 }
+                master = player.master;
             }
 
-            if (Enum.TryParse(StringFinder.GetEnumFromPartial<TeamIndex>(args[0]).ToString(), true, out TeamIndex teamIndex))
+            if (!Enum.TryParse(StringFinder.GetEnumFromPartial<TeamIndex>(args[0]).ToString(), true, out TeamIndex teamIndex))
             {
-                if ((int)teamIndex >= (int)TeamIndex.None && (int)teamIndex < (int)TeamIndex.Count)
-                {
-                    if (master.GetBody())
-                    {
-                        master.GetBody().teamComponent.teamIndex = teamIndex;
-                        master.teamIndex = teamIndex;
-                        Log.MessageNetworked("Changed to team " + teamIndex, args);
-                        return;
-                    }
-                }
-            }
-            //Note the `return` on succesful evaluation.
-            Log.MessageNetworked("Invalid team. Please check list_team for options.", args, LogLevel.MessageClientOnly);
-
-        }
-
-        [ConCommand(commandName = "loadout_set_skin_variant", flags = ConVarFlags.None, helpText = "Change your loadout's skin,  " + Lang.LOADOUTSKIN_ARGS)]
-        public static void CCLoadoutSetSkinVariant(ConCommandArgs args)
-        {
-            if (args.sender == null)
-            {
-                Log.Message(Lang.DS_REQUIREFULLQUALIFY, LogLevel.Error);
+                Log.MessageNetworked(Lang.TEAM_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-
-            if (args.Count != 2)
+            if ((int)teamIndex >= (int)TeamIndex.None && (int)teamIndex < (int)TeamIndex.Count)
             {
-                Log.Message(Lang.LOADOUTSKIN_ARGS, LogLevel.MessageClientOnly);
+                if (master.GetBody())
+                {
+                    master.GetBody().teamComponent.teamIndex = teamIndex;
+                    master.teamIndex = teamIndex;
+                    Log.MessageNetworked("Changed to team " + teamIndex, args);
+                    return;
+                }
+            }
+        }
+
+        [ConCommand(commandName = "loadout_set_skin_variant", flags = ConVarFlags.None, helpText = Lang.LOADOUTSKIN_HELP)]
+        public static void CCLoadoutSetSkinVariant(ConCommandArgs args)
+        {
+            if (args.Count < 2)
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.LOADOUTSKIN_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
             BodyIndex argBodyIndex = BodyIndex.None;
             bool bodyIsSelf = false;
 
-            if (args.Count > 0)
+            if (args[0].ToUpperInvariant() == "SELF")
             {
-                if (args.GetArgString(0).ToUpperInvariant() == "SELF")
+                bodyIsSelf = true;
+                if (args.sender == null)
                 {
-                    bodyIsSelf = true;
-                    if (args.sender == null)
-                    {
-                        Log.Message("Can't choose self if not in-game!", LogLevel.Error);
-                        return;
-                    }
-                    if (args.senderBody)
-                    {
-                        argBodyIndex = args.senderBody.bodyIndex;
-                    }
-                    else
-                    {
-                        if (args.senderMaster && args.senderMaster.bodyPrefab)
-                        {
-                            argBodyIndex = args.senderMaster.bodyPrefab.GetComponent<CharacterBody>().bodyIndex;
-                        }
-                        else
-                        {
-                            argBodyIndex = args.sender.bodyIndexPreference;
-                        }
-                    }
+                    Log.Message("Can't choose self if not in-game!", LogLevel.Error);
+                    return;
+                }
+                if (args.senderBody)
+                {
+                    argBodyIndex = args.senderBody.bodyIndex;
                 }
                 else
                 {
-                    string requestedBodyName = StringFinder.Instance.GetBodyName(args[0]);
-                    if (requestedBodyName != null)
+                    if (args.senderMaster && args.senderMaster.bodyPrefab)
                     {
-                        argBodyIndex = BodyCatalog.FindBodyIndex(requestedBodyName);
+                        argBodyIndex = args.senderMaster.bodyPrefab.GetComponent<CharacterBody>().bodyIndex;
+                    }
+                    else
+                    {
+                        argBodyIndex = args.sender.bodyIndexPreference;
                     }
                 }
             }
+            else
+            {
+                string requestedBodyName = StringFinder.Instance.GetBodyName(args[0]);
+                if (requestedBodyName == null)
+                {
+                    Log.MessageNetworked(Lang.BODY_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
+                argBodyIndex = BodyCatalog.FindBodyIndex(requestedBodyName);
+            }
 
-            int requestedSkinIndexChange = args.GetArgInt(1);
+            if (!TextSerialization.TryParseInvariant(args[1], out int requestedSkinIndexChange))
+            {
+                Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "skin_index", "int"), args, LogLevel.MessageClientOnly);
+            }
 
             Loadout loadout = new Loadout();
             UserProfile userProfile = args.GetSenderLocalUser().userProfile;
@@ -275,8 +263,6 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.PLAYER_SKINCHANGERESPAWN, args, LogLevel.MessageClientOnly);
             }
         }
-
-
 
         internal static bool UpdateCurrentPlayerBody(out NetworkUser networkUser, out CharacterBody characterBody)
         {

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -40,6 +40,11 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
+            if (!args.senderBody)
+            {
+                Log.MessageNetworked("Can't toggle noclip while you're dead. " + Lang.USE_RESPAWN, args, LogLevel.MessageClientOnly);
+                return;
+            }
             NoclipNet.Invoke(args.sender); // callback
         }
 
@@ -54,6 +59,11 @@ namespace DebugToolkit.Commands
             if (!Run.instance)
             {
                 Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            if (!args.senderBody)
+            {
+                Log.MessageNetworked("Can't toggle noclip while you're dead. " + Lang.USE_RESPAWN, args, LogLevel.MessageClientOnly);
                 return;
             }
             TeleportNet.Invoke(args.sender); // callback
@@ -100,6 +110,7 @@ namespace DebugToolkit.Commands
             if (!master.GetBody())
             {
                 Log.MessageNetworked(Lang.PLAYER_DEADRESPAWN, args);
+                return;
             }
 
             RoR2.ConVar.BoolConVar stage1pod = Stage.stage1PodConVar;
@@ -166,6 +177,11 @@ namespace DebugToolkit.Commands
                 }
                 master = player.master;
             }
+            if (!master.GetBody())
+            {
+                Log.MessageNetworked("Can't change a dead player's team. " + Lang.USE_RESPAWN, args, LogLevel.MessageClientOnly);
+                return;
+            }
 
             if (!Enum.TryParse(StringFinder.GetEnumFromPartial<TeamIndex>(args[0]).ToString(), true, out TeamIndex teamIndex))
             {
@@ -174,13 +190,9 @@ namespace DebugToolkit.Commands
             }
             if ((int)teamIndex >= (int)TeamIndex.None && (int)teamIndex < (int)TeamIndex.Count)
             {
-                if (master.GetBody())
-                {
-                    master.GetBody().teamComponent.teamIndex = teamIndex;
-                    master.teamIndex = teamIndex;
-                    Log.MessageNetworked("Changed to team " + teamIndex, args);
-                    return;
-                }
+                master.GetBody().teamComponent.teamIndex = teamIndex;
+                master.teamIndex = teamIndex;
+                Log.MessageNetworked("Changed to team " + teamIndex, args);
             }
         }
 

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -21,7 +21,7 @@ namespace DebugToolkit.Commands
                 playerInstance.master.ToggleGod();
                 if (hasNotYetRun)
                 {
-                    Log.MessageNetworked($"God mode {(playerInstance.master.GetBody().healthComponent.godMode ? "enabled" : "disabled")}.", args);
+                    Log.MessageNetworked($"God mode {(playerInstance.master.godMode ? "enabled" : "disabled")}.", args);
                     hasNotYetRun = false;
                 }
             }

--- a/Code/DT-Commands/Spawners.cs
+++ b/Code/DT-Commands/Spawners.cs
@@ -31,6 +31,11 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.SPAWNINTERACTABLE_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
+            if (!args.senderBody)
+            {
+                Log.MessageNetworked("Can't spawn an object with relation to a dead target.", args, LogLevel.MessageClientOnly);
+                return;
+            }
             var isc = StringFinder.Instance.GetInteractableSpawnCard(args[0]);
             if (isc == null)
             {
@@ -81,6 +86,11 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.SPAWNAI_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
+            if (!args.senderBody)
+            {
+                Log.MessageNetworked("Can't spawn an object with relation to a dead target.", args, LogLevel.MessageClientOnly);
+                return;
+            }
 
             string character = StringFinder.Instance.GetMasterName(args[0]);
             if (character == null)
@@ -97,7 +107,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "count", "int"), args, LogLevel.MessageClientOnly);
                 return;
             }
-            Vector3 location = args.sender.master.GetBody().transform.position;
+            Vector3 location = args.senderBody.transform.position;
             Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_2, amount, character), args);
             for (int i = 0; i < amount; i++)
             {
@@ -169,6 +179,11 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.SPAWNBODY_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
+            if (!args.senderBody)
+            {
+                Log.MessageNetworked("Can't spawn an object with relation to a dead target.", args, LogLevel.MessageClientOnly);
+                return;
+            }
 
             string character = StringFinder.Instance.GetBodyName(args[0]);
             if (character == null)
@@ -178,7 +193,7 @@ namespace DebugToolkit.Commands
             }
 
             GameObject body = BodyCatalog.FindBodyPrefab(character);
-            GameObject gameObject = UnityEngine.Object.Instantiate<GameObject>(body, args.sender.master.GetBody().transform.position, Quaternion.identity);
+            GameObject gameObject = UnityEngine.Object.Instantiate<GameObject>(body, args.senderBody.transform.position, Quaternion.identity);
             NetworkServer.Spawn(gameObject);
             Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_1, character), args);
         }

--- a/Code/DT-Commands/Spawners.cs
+++ b/Code/DT-Commands/Spawners.cs
@@ -12,50 +12,15 @@ namespace DebugToolkit.Commands
     class Spawners
     {
 
-        [ConCommand(commandName = "spawn_interactable", flags = ConVarFlags.ExecuteOnServer, helpText = "Spawns the specified interactable. List_Interactable for options. " + Lang.SPAWNINTERACTABLE_ARGS)]
+        [ConCommand(commandName = "spawn_interactable", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.SPAWNINTERACTABLE_HELP)]
         [AutoCompletion(typeof(StringFinder), "interactableSpawnCards", "", true)]
         private static void CCSpawnInteractable(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.SPAWNINTERACTABLE_ARGS, args, LogLevel.ErrorClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
-            try
-            {
-                var isc = StringFinder.Instance.GetInteractableSpawnCard(args[0]);
-                isc.DoSpawn(args.senderBody.transform.position, new Quaternion(), new DirectorSpawnRequest(
-                    isc,
-                    new DirectorPlacementRule
-                    {
-                        placementMode = DirectorPlacementRule.PlacementMode.NearestNode,
-                        maxDistance = 100f,
-                        minDistance = 20f,
-                        position = args.senderBody.transform.position,
-                        preventOverhead = true
-                    },
-                    RoR2Application.rng)
-                );
-            }
-            catch (Exception ex)
-            {
-                Log.MessageNetworked(ex.ToString(), args, LogLevel.ErrorClientOnly);
-            }
-        }
-
-        [ConCommand(commandName = "spawn_interactible", flags = ConVarFlags.ExecuteOnServer, helpText = "Spawns the specified interactable. List_Interactable for options. " + Lang.SPAWNINTERACTABLE_ARGS)]
-        [AutoCompletion(typeof(StringFinder), "interactableSpawnCards", "", true)]
-        private static void CCSpawnInteractible(ConCommandArgs args)
-        {
-            CCSpawnInteractable(args);
-        }
-
-        [ConCommand(commandName = "spawn_ai", flags = ConVarFlags.ExecuteOnServer, helpText = "Spawns the specified CharacterMaster. " + Lang.SPAWNAI_ARGS)]
-        [AutoCompletion(typeof(MasterCatalog), "aiMasterPrefabs")]
-        private static void CCSpawnAI(ConCommandArgs args)
-        {
-            //- Spawns the specified CharacterMaster. Requires 1 argument: spawn_ai 0:{localised_objectname} 1:[Count:1] 2:[EliteIndex:-1/None] 3:[Braindead:0/false(0|1)] 4:[TeamIndex:0/Neutral]
-
             if (args.sender == null)
             {
                 Log.Message(Lang.DS_NOTYETIMPLEMENTED, LogLevel.Error);
@@ -63,7 +28,57 @@ namespace DebugToolkit.Commands
             }
             if (args.Count == 0)
             {
-                Log.MessageNetworked(Lang.SPAWNAI_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.SPAWNINTERACTABLE_ARGS, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            var isc = StringFinder.Instance.GetInteractableSpawnCard(args[0]);
+            if (isc == null)
+            {
+                Log.MessageNetworked(Lang.INTERACTABLE_NOTFOUND, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            var result = isc.DoSpawn(args.senderBody.transform.position, new Quaternion(), new DirectorSpawnRequest(
+                isc,
+                new DirectorPlacementRule
+                {
+                    placementMode = DirectorPlacementRule.PlacementMode.NearestNode,
+                    maxDistance = 100f,
+                    minDistance = 20f,
+                    position = args.senderBody.transform.position,
+                    preventOverhead = true
+                },
+                RoR2Application.rng)
+            );
+            if (!result.success)
+            {
+                Log.MessageNetworked("Failed to spawn interactable.", args, LogLevel.MessageClientOnly);
+            }
+        }
+
+        [ConCommand(commandName = "spawn_interactible", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.SPAWNINTERACTABLE_HELP)]
+        [AutoCompletion(typeof(StringFinder), "interactableSpawnCards", "", true)]
+        private static void CCSpawnInteractible(ConCommandArgs args)
+        {
+            CCSpawnInteractable(args);
+        }
+
+        [ConCommand(commandName = "spawn_ai", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.SPAWNAI_HELP)]
+        [AutoCompletion(typeof(MasterCatalog), "aiMasterPrefabs")]
+        private static void CCSpawnAI(ConCommandArgs args)
+        {
+            if (!Run.instance)
+            {
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
+                return;
+            }
+            if (args.sender == null)
+            {
+                Log.Message(Lang.DS_NOTYETIMPLEMENTED, LogLevel.Error);
+                return;
+            }
+            if (args.Count == 0)
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.SPAWNAI_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 
@@ -77,13 +92,10 @@ namespace DebugToolkit.Commands
             var body = masterprefab.GetComponent<CharacterMaster>().bodyPrefab;
 
             int amount = 1;
-            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
+            if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE && !TextSerialization.TryParseInvariant(args[1], out amount))
             {
-                if (int.TryParse(args[1], out amount) == false)
-                {
-                    Log.MessageNetworked(Lang.SPAWNAI_ARGS, args, LogLevel.MessageClientOnly);
-                    return;
-                }
+                Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "count", "int"), args, LogLevel.MessageClientOnly);
+                return;
             }
             Vector3 location = args.sender.master.GetBody().transform.position;
             Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_2, amount, character), args);
@@ -106,19 +118,30 @@ namespace DebugToolkit.Commands
                         master.inventory.GiveItem(RoR2Content.Items.BoostHp, Mathf.RoundToInt((eliteDef.healthBoostCoefficient - 1) * 10));
                         master.inventory.GiveItem(RoR2Content.Items.BoostDamage, Mathf.RoundToInt(eliteDef.damageBoostCoefficient - 1) * 10);
                     }
+                    else
+                    {
+                        Log.MessageNetworked(Lang.ELITE_NOTFOUND, args, LogLevel.MessageClientOnly);
+                        return;
+                    }
                 }
 
-                if (args.Count > 3 && args[3] != Lang.DEFAULT_VALUE && Util.TryParseBool(args[3], out bool braindead) && braindead)
+                bool braindead = false;
+                if (args.Count > 3 && args[3] != Lang.DEFAULT_VALUE && !Util.TryParseBool(args[3], out braindead))
+                {
+                    Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "braindead", "int or bool"), args, LogLevel.MessageClientOnly);
+                    return;
+                }
+                if (braindead)
                 {
                     UnityEngine.Object.Destroy(master.GetComponent<BaseAI>());
                 }
 
                 TeamIndex teamIndex = TeamIndex.Monster;
-                if (args.Count > 4 && args[4] != Lang.DEFAULT_VALUE)
+                if (args.Count > 4 && args[4] != Lang.DEFAULT_VALUE && !StringFinder.TryGetEnumFromPartial(args[4], out teamIndex))
                 {
-                    StringFinder.TryGetEnumFromPartial(args[4], out teamIndex);
+                    Log.MessageNetworked(Lang.TEAM_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
                 }
-
                 if (teamIndex >= TeamIndex.None && teamIndex < TeamIndex.Count)
                 {
                     master.teamIndex = teamIndex;
@@ -127,18 +150,23 @@ namespace DebugToolkit.Commands
             }
         }
 
-        [ConCommand(commandName = "spawn_body", flags = ConVarFlags.ExecuteOnServer, helpText = "Spawns the specified dummy body. " + Lang.SPAWNBODY_ARGS)]
+        [ConCommand(commandName = "spawn_body", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.SPAWNBODY_HELP)]
         [AutoCompletion(typeof(BodyCatalog), "bodyPrefabBodyComponents", "baseNameToken")]
         private static void CCSpawnBody(ConCommandArgs args)
         {
-            if (args.Count == 0)
+            if (!Run.instance)
             {
-                Log.MessageNetworked(Lang.SPAWNBODY_ARGS, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
             if (args.sender == null)
             {
                 Log.Message(Lang.DS_NOTYETIMPLEMENTED, LogLevel.Error);
+                return;
+            }
+            if (args.Count == 0)
+            {
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.SPAWNBODY_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
 

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -21,7 +21,7 @@ namespace DebugToolkit
         private const ConVarFlags AllFlagsNoCheat = ConVarFlags.None | ConVarFlags.Archive | ConVarFlags.Engine | ConVarFlags.ExecuteOnServer | ConVarFlags.SenderMustBeServer;
 
         private static On.RoR2.Console.orig_RunCmd _origRunCmd;
-        private static CharacterBody pingedBody;
+        private static CharacterMaster pingedTarget;
         public static void InitializeHooks()
         {
             IL.RoR2.Console.Awake += UnlockConsole;
@@ -54,10 +54,10 @@ namespace DebugToolkit
             orig(self, pingInfo);
             if (self.pingIndicator & self.pingIndicator.pingTarget)
             {
-                pingedBody = self.pingIndicator.pingTarget.GetComponent<CharacterBody>();
+                pingedTarget = self.pingIndicator.pingTarget.GetComponent<CharacterBody>()?.master;
                 return;
             }
-            pingedBody = null;
+            pingedTarget = null;
         }
 
         private static void OverrideVanillaSceneList(On.RoR2.Networking.NetworkManagerSystem.orig_CCSceneList orig, ConCommandArgs args)
@@ -390,9 +390,9 @@ namespace DebugToolkit
             return;
         }
 
-        internal static CharacterBody GetPingedBody()
+        internal static CharacterMaster GetPingedTarget()
         {
-            return pingedBody;
+            return pingedTarget;
         }
     }
 }

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -2,99 +2,160 @@
 {
     public static class Lang
     {
-        // `{}` denotes necessary, `()` a list of specifc choices, `[]` optional, `:` denotes a default
+        // `{}` denotes necessary, `()` a list of specific choices, `[]` optional, `:` denotes a default
+
+        // Command arguments
         public const string
-            ADDPORTAL_ARGS = "Requires 1 argument: ('blue'|'gold'|'celestial'|'null'|'void'|'deepvoid'|'all')",
+            ADDPORTAL_ARGS = "Requires 1 argument: {portal ('blue'|'gold'|'celestial'|'null'|'void'|'deepvoid'|'all')}",
             BAN_ARGS = "Requires 1 argument: {player}",
             BIND_ARGS = "Requires 2 arguments: {key} {console_commands}",
             BIND_DELETE_ARGS = "Requires 1 argument: {key}",
-            CHANGETEAM_ARGS = "Requires 1 argument: {team} [player]",
-            CREATEPICKUP_ARGS = "Requires 1 argument: (object|'coin') [search ('item'|'equip'):<both>]",
-            FAMILYEVENT_ARGS = "Requires 0 arguments.",
-            FIXEDTIME_ARGS = "Requires 1 argument: [time]",
-            GIVEEQUIP_ARGS = "Requires 1 (2 if from server) argument: [equip} [(player|'pinged'):<self>]",
-            GIVEITEM_ARGS = "Requires 1 (3 if from server) argument: {item} [count:1] [(player|'pinged'):<self>]",
-            GIVELUNAR_ARGS = "Requires 0 arguments: [count:1]",
-            GIVEMONEY_ARGS = "Requires 1 argument: {count} [(player|'all')]",
-            GOD_ARGS = "Requires 0 arguments.",
-            NOCLIP_ARGS = "Requires 0 arguments.",
-            CURSORTELEPORT_ARGS = "Requires no arguments: teleport_on_cursor",
-            LOADOUTSKIN_ARGS = "Requires 2 argument: loadout_set_skin_variant {(body|'self')} {skin_index}",
-            LOCKEXP_ARGS = "Requires 0 arguments.",
+            CHANGETEAM_ARGS = "Requires 1 (2 if from server) argument: {team} [player]",
+            CREATEPICKUP_ARGS = "Requires 1 (3 if from server) argument: {object (item|equip|'coin')} [search ('item'|'equip'):<both>] [player:<self>]",
+            FIXEDTIME_ARGS = "Requires 0 or 1 argument: [time]",
+            GIVEEQUIP_ARGS = "Requires 1 (2 if from server) argument: {equip} [target (player|'pinged'):<self>]",
+            GIVEITEM_ARGS = "Requires 1 (3 if from server) argument: {item} [count:1] [target (player|'pinged'):<self>]",
+            GIVELUNAR_ARGS = "Requires 0 arguments: [amount:1]",
+            GIVEMONEY_ARGS = "Requires 1 argument: {amount} [target (player|'all')]",
             KICK_ARGS = "Requires 1 argument: {player}",
             KILLALL_ARGS = "Requires 0 arguments: [team:Monster]",
-            NEXTBOSS_ARGS = "Requires 1 argument: (csc|director_card) [count:1] [elite:None]",
+            LISTSKIN_ARGS = "Requires 0 arguments: [body|'all'|'body' <separated by body>|'self'):'all']",
+            LISTQUERY_ARGS = "Requires 0 arguments: [query]",
+            LOADOUTSKIN_ARGS = "Requires 2 argument: {(body|'self')} {skin_index}",
+            NEXTBOSS_ARGS = "Requires 1 argument: {director_card} [count:1] [elite:None]",
             NEXTSTAGE_ARGS = "Requires 0 arguments: [stage]",
-            NOENEMIES_ARGS = "Requires 0 arguments.",
-            PERM_ENABLE_ARGS = "Requires no argument.",
-            PERM_MOD_ARGS = "Requires 2 arguments: (PermissionLevel (0 OR None|1 OR SubAdmin|2 OR Admin) (player)",
-            RANDOM_ITEM_ARGS = "Requires 1 (2 if from server) argument: {count} [(player|'pinged'):<self>]",
-            REMOVEALLITEMS_ARGS = "Requires 0 (1 if from server) arguments: [(player|'pinged'):<self>]",
-            REMOVEEQUIP_ARGS = "Requires 0 (1 if from server) arguments: [(player|'pinged'):<self>]",
-            REMOVEITEM_ARGS = "Requires 1 (3 if from server) argument: {item} [count:1] [(player|'pinged'):<self>]",
-            REMOVEITEMSTACKS_ARGS = "Requires 1 (2 if from server) argument: {item} [(player|'pinged'):<self>]",
-            RESPAWN_ARGS = "Requires 0 arguments: [(player|'pinged'):<self>]",
+            NO_ARGS = "Requires 0 arguments.",
+            PERM_ENABLE_ARGS = "Requires 0 or 1 arguments: [value]",
+            PERM_MOD_ARGS = "Requires 2 arguments: (permission_level (0 OR None|1 OR SubAdmin|2 OR Admin) (player)",
+            POSTSOUNDEVENT_ARGS = "Requires 1 argument: {event_name}",
+            RANDOMITEM_ARGS = "Requires 1 (2 if from server) argument: {count} [target (player|'pinged'):<self>]",
+            REMOVEALLITEMS_ARGS = "Requires 0 (1 if from server) arguments: [target (player|'pinged'):<self>]",
+            REMOVEEQUIP_ARGS = "Requires 0 (1 if from server) arguments: [target (player|'pinged'):<self>]",
+            REMOVEITEM_ARGS = "Requires 1 (3 if from server) argument: {item} [count:1] [target (player|'pinged'):<self>]",
+            REMOVEITEMSTACKS_ARGS = "Requires 1 (2 if from server) argument: {item} [target (player|'pinged'):<self>]",
+            RESPAWN_ARGS = "Requires 0 (1 if from server) arguments: [player:<self>]",
             SEED_ARGS = "Requires 0 or 1 argument: [new_seed]",
             SPAWNAI_ARGS = "Requires 1 argument: {ai} [count:1] [elite:None] [braindead (0|1):0/false] [team:Monster]",
-            SPAWNAS_ARGS = "Requires 1 argument: [body] [(player|'pinged'):<self>]",
+            SPAWNAS_ARGS = "Requires 1 argument: {body} [player:<self>]",
             SPAWNBODY_ARGS = "Requires 1 argument: {body}",
             SPAWNINTERACTABLE_ARGS = "Requires 1 argument: {interactable}",
             TIMESCALE_ARGS = "Requires 1 argument: {time_scale}",
-            TRUEKILL_ARGS = "Requires 0 arguments: [(player|'pinged'):<self>]"
+            TRUEKILL_ARGS = "Requires 0 (1 if from server) arguments: [player:<self>]"
             ;
 
+        // Command help texts
         public const string
-            LISTITEM_ARGS = "List all item names and their IDs. Requires 0 arguments: [query]",
-            LISTEQUIP_ARGS = "List all equipment items and their IDs. Requires 0 arguments: [query]",
-            LISTAI_ARGS = "List all Masters and their language invariants. Requires 0 arguments: [query]",
-            LISTELITE_ARGS = "List all Elites and their language invariants. Requires 0 arguments: [query]",
-            LISTTEAM_ARGS = "List all Teams and their language invariants. Requires 0 arguments: [query]",
-            LISTBODY_ARGS = "List all Bodies and their language invariants. Requires 0 arguments: [query]",
-            LISTPLAYER_ARGS = "List all players and their ID. Requires 0 arguments: [query]",
-            LISTSKIN_ARGS = "List all bodies with skins. Requires 0 arguments: list_skin [{localised_objectname}|'all'|'body' <separated by body>|'self'):'all']",
-            LISTINTERACTABLE_ARGS = "Lists all interactables. Requires 0 arguments: [query]"
+            ADDPORTAL_HELP = "Add a portal to the current Teleporter on completion. " + ADDPORTAL_ARGS,
+            BAN_HELP = "Bans the specified player from the session. " + BAN_ARGS,
+            CHANGETEAM_HELP = "Change the specified player to the specified team. " + CHANGETEAM_ARGS,
+            CREATEPICKUP_HELP = "Creates a PickupDroplet infront of your position. " + CREATEPICKUP_ARGS,
+            CURSORTELEPORT_HELP = "Teleport you to where your cursor is currently aiming at. " + NO_ARGS,
+            FAMILYEVENT_HELP = "Forces a family event to occur during the next stage. " + NO_ARGS,
+            FIXEDTIME_HELP = "Sets the run timer to the specified value. " + FIXEDTIME_ARGS,
+            GIVEEQUIP_HELP = "Gives the specified equipment to a character. " + GIVEEQUIP_ARGS,
+            GIVEITEM_HELP = "Gives the specified item to a character. " + GIVEITEM_ARGS,
+            GIVELUNAR_HELP = "Gives a lunar coin to you. " + GIVELUNAR_ARGS,
+            GIVEMONEY_HELP = "Gives the specified amount of money to the specified player. " + GIVEMONEY_ARGS,
+            GOD_HELP = "Become invincible. " + NO_ARGS,
+            KICK_HELP = "Kicks the specified player from the session. " + KICK_ARGS,
+            KILLALL_HELP = "Kill all entities on the specified team. " + KILLALL_ARGS,
+            LISTAI_HELP = "List all Masters and their language invariants. " + LISTQUERY_ARGS,
+            LISTBODY_HELP = "List all Bodies and their language invariants. " + LISTQUERY_ARGS,
+            LISTDIRECTORCARDS_HELP = "List all Director Cards. " + LISTQUERY_ARGS,
+            LISTELITE_HELP = "List all Elites and their language invariants. " + LISTQUERY_ARGS,
+            LISTEQUIP_HELP = "List all equipment and their availability. " + LISTQUERY_ARGS,
+            LISTINTERACTABLE_HELP = "Lists all interactables. " + LISTQUERY_ARGS,
+            LISTITEM_HELP = "List all items and their availability. " + LISTQUERY_ARGS,
+            LISTPLAYER_HELP = "List all players and their ID. " + LISTQUERY_ARGS,
+            LISTSKIN_HELP = "List all bodies with skins. " + LISTSKIN_ARGS,
+            LISTTEAM_HELP = "List all Teams and their language invariants. " + LISTQUERY_ARGS,
+            LOADOUTSKIN_HELP = "Change your loadout's skin.  " + LOADOUTSKIN_ARGS,
+            LOCKEXP_HELP = "Toggle Experience gain. " + NO_ARGS,
+            MACRO_DTZOOM_HELP = "Gives you 20 hooves and 200 feathers for getting around quickly.",
+            MACRO_LATEGAME_HELP = "Sets the current run to the 'lategame' as defined by HG. This command is DESTRUCTIVE.",
+            MACRO_MIDGAME_HELP = "Sets the current run to the 'midgame' as defined by HG. This command is DESTRUCTIVE.",
+            NEXTBOSS_HELP = "Sets the next teleporter instance to the specified boss. " + NEXTBOSS_ARGS,
+            NEXTSTAGE_HELP = "Forces a stage change to the specified stage. " + NEXTSTAGE_ARGS,
+            NOCLIP_HELP = "Allow flying and going through objects. Sprinting will double the speed. " + NO_ARGS,
+            NOENEMIES_HELP = "Toggle Monster spawning. " + NO_ARGS,
+            PERM_ENABLE_HELP = "Enable or disable the permission system." + PERM_ENABLE_ARGS,
+            PERM_MOD_HELP = "Change the permission level of the specified playerid/username" + PERM_MOD_ARGS,
+            PERM_RELOAD_HELP = "Reload the permission system, updates user and commands permissions.",
+            POSTSOUNDEVENT_HELP = "Post a sound event to the AkSoundEngine (WWise) by its event name. " + POSTSOUNDEVENT_ARGS,
+            RANDOMITEM_HELP = "Generates the specified amount of items for a character from the available item pools at random. " + RANDOMITEM_ARGS,
+            RELOADCONFIG_HELP = "Reload all default config files from all loaded plugins.",
+            REMOVEALLITEMS_HELP = "Removes all items from a character. " + REMOVEALLITEMS_ARGS,
+            REMOVEEQUIP_HELP = "Removes the equipment from a character. " + REMOVEEQUIP_ARGS,
+            REMOVEITEM_HELP = "Removes the specified quantities of an item from a character. " + REMOVEITEM_ARGS,
+            REMOVEITEMSTACKS_HELP = "Removes all the stacks of a specified item from a character. " + REMOVEITEMSTACKS_ARGS,
+            RESPAWN_HELP = "Respawns the specified player. " + RESPAWN_ARGS,
+            SEED_HELP = "Gets/Sets the game seed until game close. Use 0 to reset to vanilla generation. " + SEED_ARGS,
+            SPAWNAS_HELP = "Respawn the specified player using the specified body prefab. " + SPAWNAS_ARGS,
+            SPAWNAI_HELP = "Spawns the specified CharacterMaster. " + SPAWNAI_ARGS,
+            SPAWNBODY_HELP = "Spawns the specified dummy body. " + SPAWNBODY_ARGS,
+            SPAWNINTERACTABLE_HELP = "Spawns the specified interactable. List_Interactable for options. " + SPAWNINTERACTABLE_ARGS,
+            TIMESCALE_HELP = "Sets the Time Delta. " + TIMESCALE_ARGS,
+            TRUEKILL_HELP = "Ignore Dio's and kill the entity. " + TRUEKILL_ARGS
             ;
 
+        // Messages
         public const string
             CREATEPICKUP_AMBIGIOUS_2 = "Could not choose between {0} and {1}, please be more precise. Consider using 'equip' or 'item' as the second argument.",
             CREATEPICKUP_NOTFOUND = "Could not find any item nor equipment with that name. It's not a coin either.",
             CREATEPICKUP_SUCCES_1 = "Succesfully created the pickup {0}.",
-            COUNTISNUMERIC = "Count must be numeric!",
-
             GIVELUNAR_2 = "{0} {1} lunar coin(s).",
             GIVEOBJECT = "Gave {0} {1}",
-            INTEGER_EXPECTED = "Argument must be a whole number.",
-            OBJECT_NOTFOUND = "The requested object could not be found: ",
             OBSOLETEWARNING = "This command has become obsolete and will be removed in the next version. ",
             NETWORKING_OTHERPLAYER_4 = "{0}({1}) issued: {2} {3}",
-            NEXTROUND_STAGE = "Invalid Stage. Please choose from the following: ",
             NOMESSAGE = "Yell at the modmakers if you see this message!",
             NOCLIP_TOGGLE = "Noclip toggled to {0}",
             PARTIALIMPLEMENTATION_WARNING = "WARNING: PARTIAL IMPLEMENTATION. WIP.",
-            PLAYER_DEADRESPAWN = "Player is will spawn as the specified body next round. (Use 'respawn' to skip the wait)",
+            PLAYER_DEADRESPAWN = "Player will spawn as the specified body next round. (Use 'respawn' to skip the wait)",
             PLAYER_SKINCHANGERESPAWN = "Player will spawn with the specified skin next round. (Use 'respawn' to skip the wait)",
-            PLAYER_NOTFOUND = "Specified player does not exist",
-            PINGEDBODY_NOTFOUND = "Pinged target not found. Either the last ping was not a character, or it has been destroyed since.",
-            PORTAL_NOTFOUND = "The specified portal could not be found. Valid portals: 'blue','gold','celestial','null','void','deepvoid','all'",
             RUNSETSTAGESCLEARED_HELP = "Sets the amount of stages cleared. This does not change the current stage.",
             SPAWN_ATTEMPT_1 = "Attempting to spawn: {0}",
-            SPAWN_ATTEMPT_2 = "Attempting to spawn {0}: {1}",
-            SPAWN_ERROR = "Could not spawn: ",
-            NOTINARUN_ERROR = "This command only works when in a Run !",
-            INVENTORY_ERROR = "The selected target has no inventory.",
-            ALL = "ALL",
-            DEFAULT_VALUE = "",
-            PINGED = "PINGED"
+            SPAWN_ATTEMPT_2 = "Attempting to spawn {0}: {1}"
             ;
 
+        // Errors
+        public const string
+            BODY_NOTFOUND = "Specified body not found. Please use list_body for options.",
+            ELITE_NOTFOUND = "Elite type not recognized. Please use list_elite for options.",
+            INSUFFICIENT_ARGS = "Insufficient number of arguments. ",
+            INTERACTABLE_NOTFOUND = "Interactable not found. Please use list_interactables for options.",
+            INVALID_ARG_VALUE = "Invalid value for {0}.",
+            INVENTORY_ERROR = "The selected target has no inventory.",
+            NOTINARUN_ERROR = "This command only works when in a Run!",
+            OBJECT_NOTFOUND = "The requested object could not be found: ",
+            PARSE_ERROR = "Unable to parse {0} to {1}.",
+            PINGEDBODY_NOTFOUND = "Pinged target not found. Either the last ping was not a character, or it has been destroyed since.",
+            PLAYER_NOTFOUND = "Specified player does not exist. Please use list_player for options.",
+            PORTAL_NOTFOUND = "The specified portal could not be found. Valid portals: 'blue','gold','celestial','null','void','deepvoid','all'",
+            SPAWN_ERROR = "Could not spawn: ",
+            STAGE_NOTFOUND = "Stage not found. Please use scene_list for options.",
+            TEAM_NOTFOUND = "Team type not found. Please use list_team for options."
+            ;
+
+        // Keywords
+        public const string
+            ALL = "ALL",
+            COIN = "COIN",
+            DEFAULT_VALUE = "",
+            EQUIP = "EQUIP",
+            ITEM = "ITEM",
+            PINGED = "PINGED",
+            RANDOM = "RANDOM"
+            ;
+
+        // Permissions
         public const string
             PS_ARGUSER_HAS_MORE_PERM = "Specified user {0} has a greater permission level than you.",
             PS_ARGUSER_HAS_SAME_PERM = "Specified user {0} has the same permission level as you.",
             PS_NO_REQUIRED_LEVEL = "You don't have the required permission {0} to use this command."
             ;
 
+        // Dedicated server
         public const string
-            DS_REQUIREFULLQUALIFY = "Command must be fully qualified on dedicated servers.",
             DS_NOTAVAILABLE = "This command doesn't make sense to run from a dedicated server.",
             DS_NOTYETIMPLEMENTED = "This command has not yet been implemented to be run from a dedicated server,"
             ;

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -110,11 +110,12 @@
             NOMESSAGE = "Yell at the modmakers if you see this message!",
             NOCLIP_TOGGLE = "Noclip toggled to {0}",
             PARTIALIMPLEMENTATION_WARNING = "WARNING: PARTIAL IMPLEMENTATION. WIP.",
-            PLAYER_DEADRESPAWN = "Player will spawn as the specified body next round. (Use 'respawn' to skip the wait)",
-            PLAYER_SKINCHANGERESPAWN = "Player will spawn with the specified skin next round. (Use 'respawn' to skip the wait)",
+            PLAYER_DEADRESPAWN = "Player will spawn as the specified body next round. " + USE_RESPAWN,
+            PLAYER_SKINCHANGERESPAWN = "Player will spawn with the specified skin next round. " + USE_RESPAWN,
             RUNSETSTAGESCLEARED_HELP = "Sets the amount of stages cleared. This does not change the current stage.",
             SPAWN_ATTEMPT_1 = "Attempting to spawn: {0}",
-            SPAWN_ATTEMPT_2 = "Attempting to spawn {0}: {1}"
+            SPAWN_ATTEMPT_2 = "Attempting to spawn {0}: {1}",
+            USE_RESPAWN = "Use 'respawn' to skip the wait."
             ;
 
         // Errors
@@ -129,7 +130,7 @@
             OBJECT_NOTFOUND = "The requested object could not be found: ",
             PARSE_ERROR = "Unable to parse {0} to {1}.",
             PINGEDBODY_NOTFOUND = "Pinged target not found. Either the last ping was not a character, or it has been destroyed since.",
-            PLAYER_NOTFOUND = "Specified player does not exist. Please use list_player for options.",
+            PLAYER_NOTFOUND = "Specified player not found or isn't alive. Please use list_player for options.",
             PORTAL_NOTFOUND = "The specified portal could not be found. Valid portals: 'blue','gold','celestial','null','void','deepvoid','all'",
             SPAWN_ERROR = "Could not spawn: ",
             STAGE_NOTFOUND = "Stage not found. Please use scene_list for options.",

--- a/Code/PermissionSystem.cs
+++ b/Code/PermissionSystem.cs
@@ -157,7 +157,7 @@ namespace DebugToolkit.Permissions
             }
         }
 
-        [ConCommand(commandName = "perm_reload", flags = ConVarFlags.ExecuteOnServer, helpText = "Reload the permission system, updates user and commands permissions.")]
+        [ConCommand(commandName = "perm_reload", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.PERM_RELOAD_HELP)]
         [RequiredLevel(Level.Admin)]
         private static void CCReloadPermissionSystem(ConCommandArgs args)
         {
@@ -166,7 +166,7 @@ namespace DebugToolkit.Permissions
             Log.MessageNetworked("Config File of DebugToolkit / Permission System successfully reloaded.", args, Log.LogLevel.Info);
         }
 
-        [ConCommand(commandName = "perm_enable", flags = ConVarFlags.ExecuteOnServer, helpText = "Enable or disable the permission system." + Lang.PERM_ENABLE_ARGS)]
+        [ConCommand(commandName = "perm_enable", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.PERM_ENABLE_HELP)]
         [RequiredLevel(Level.Admin)]
         private static void CCPermissionEnable(ConCommandArgs args)
         {
@@ -176,7 +176,12 @@ namespace DebugToolkit.Permissions
             }
             else
             {
-                IsEnabled.Value = args.GetArgBool(0);
+                if (!bool.TryParse(args[0], out bool value))
+                {
+                    Log.MessageNetworked(String.Format(Lang.PARSE_ERROR, "value", "bool"), args, Log.LogLevel.ErrorClientOnly);
+                    return;
+                }
+                IsEnabled.Value = value;
             }
 
             var res = IsEnabled.Value ? "enabled. Saving and reloading the permission system" : "disabled";
@@ -186,13 +191,13 @@ namespace DebugToolkit.Permissions
             Init();
         }
 
-        [ConCommand(commandName = "perm_mod", flags = ConVarFlags.ExecuteOnServer, helpText = "Change the permission level of the specified playerid/username" + Lang.PERM_MOD_ARGS)]
+        [ConCommand(commandName = "perm_mod", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.PERM_MOD_HELP)]
         [RequiredLevel(Level.Admin)]
         private static void CCPermissionAddUser(ConCommandArgs args)
         {
             if (args.Count == 0)
             {
-                Log.MessageNetworked(Lang.PERM_MOD_ARGS, args, Log.LogLevel.Error);
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.PERM_MOD_ARGS, args, Log.LogLevel.Error);
                 return;
             }
             try

--- a/Code/Util.cs
+++ b/Code/Util.cs
@@ -17,6 +17,7 @@ namespace DebugToolkit
         {
             if (args.Count > 0 && startLocation < args.Count)
             {
+                // This doesn't seem to be necessary
                 if (args[startLocation].StartsWith("\""))
                 {
                     var startString = string.Join(" ", args);
@@ -33,8 +34,6 @@ namespace DebugToolkit
                     {
                         return NetworkUser.readOnlyInstancesList[result];
                     }
-
-                    Log.Message(Lang.PLAYER_NOTFOUND);
                     return null;
                 }
 
@@ -45,10 +44,8 @@ namespace DebugToolkit
                         return n;
                     }
                 }
-
                 return null;
             }
-
             return null;
         }
 

--- a/Code/Util.cs
+++ b/Code/Util.cs
@@ -55,28 +55,17 @@ namespace DebugToolkit
         /// <param name="args">(string[])args array</param>
         /// <param name="index">(int)on the string array, at which index the target string is</param>
         /// <param name="isDedicatedServer">whether the command has been submitted from a dedicated server</param>
-        /// <returns>Returns the found body. Null otherwise</returns>
-        internal static CharacterBody GetBodyFromArgs(List<string> args, int index, bool isDedicatedServer)
+        /// <returns>Returns the found master. Null otherwise</returns>
+        internal static CharacterMaster GetTargetFromArgs(List<string> args, int index, bool isDedicatedServer)
         {
-            CharacterBody target = null;
-            if (isDedicatedServer)
+            CharacterMaster target;
+            if (!isDedicatedServer && args[index].ToUpper() == Lang.PINGED)
             {
-                target = GetNetUserFromString(args, index)?.GetCurrentBody();
+                target = Hooks.GetPingedTarget();
             }
             else
             {
-                if (args[index].ToUpper() == Lang.PINGED)
-                {
-                    var pingedBody = Hooks.GetPingedBody();
-                    if (pingedBody)
-                    {
-                        target = pingedBody;
-                    }
-                }
-                else
-                {
-                    target = GetNetUserFromString(args, index)?.GetCurrentBody();
-                }
+                target = GetNetUserFromString(args, index)?.master;
             }
             return target;
         }

--- a/README.md
+++ b/README.md
@@ -39,19 +39,19 @@ You may contact us at any time through [issues on GitHub](https://github.com/har
 Verbiage:
 - The brackets encapsulating arguments mean `{needed}`, `(choose one)`, and `[optional]`.
 - If an optional argument has a default value, it will be indicated with `:`. Any preceeding optional arguments from the one entered become necessary, but empty double quotes can be used as a placeholder for the default value. If an optional argument is required from a dedicated server, it will be preceeded by `*`.
-- Player, body, AI, item, equipment, team, elite, and interactable values can be declared by either their ID, or their string name. The latter can be written in freeform and it will be matched to the first result that contains the string. See the related `list_` commands for options and which result would take precedence if there are multiple matches.
+- Player, body, AI, item, equipment, team, elite, interactable, and director card values can be declared by either their ID, or their string name. The latter can be written in freeform and it will be matched to the first result that contains the string. See the related `list_` commands for options and which result would take precedence if there are multiple matches.
 
 Commands:
 
 * **next_stage** - Advance to the next stage. `next_stage [specific_stage]`. If no stage is entered, the next stage in progression is selected.
 * **force_family_event** - Forces a Family Event to happen in the next stage, takes no arguments. `force_family_event`
-* **next_boss** - Sets the teleporter boss to the specified boss. Get a list of potential boss with `list_directorcards` `next_boss {(csc|director_card)} [count:1] [elite:None]`
+* **next_boss** - Sets the teleporter boss to the specified boss. Get a list of potential boss with `list_directorcards`. `next_boss {director_card} [count:1] [elite:None]`
 * **fixed_time** - Sets the time that has progressed in the run. Affects difficulty. `fixed_time [time]`. If no time is supplied, prints the current time to console.
-* **add_portal** - Teleporter will attempt to spawn after the teleporter completion. `add_portal {('blue'|'gold'|'celestial'|'null'|'void'|'deepvoid'|'all')}`. The `null` portal doesn't require a teleporter and will spawn in front of the player.
+* **add_portal** - Teleporter will attempt to spawn after the teleporter completion. `add_portal {portal ('blue'|'gold'|'celestial'|'null'|'void'|'deepvoid'|'all')}`. The `null` portal doesn't require a teleporter and will spawn in front of the player.
 * **seed** - Set the seed for all next runs this session. `seed [new_seed]`. Use `0` to specify the game should generate its own seed. If used without argument, it's equivalent to the vanilla `run_get_seed`.
 * **kill_all** - Kills all members of a specified team. `kill_all [team:Monster]`.
-* **true_kill** - Truly kill a player, ignoring revival effects. `true_kill [target player:<self>]`
-* **respawn** - Respawn a player at the map spawnpoint. `respawn [target player:<self>]`
+* **true_kill** - Truly kill a player, ignoring revival effects. `true_kill *[player:<self>]`
+* **respawn** - Respawn a player at the map spawnpoint. `respawn *[player:<self>]`
 * **teleport_on_cursor** -  Teleport you to where your cursor is currently aiming at. `teleport_on_cursor`
 * **time_scale** -  Sets the timescale of the game. 0.5 would mean everything happens at half speed. `time_scale [time_scale]`. If no argument is supplied, gives the current timescale.
 * **post_sound_event** - Post a sound event to the AkSoundEngine (WWise) by its event name: `post_sound_event {event_name}`
@@ -81,15 +81,15 @@ Item Commands:
 * **remove_item_stacks** - Removes all item stacks from a character's inventory. `remove_item_stacks {item} *[target (player|'pinged'):<self>]`
 * **remove_all_items** - Removes all items from a character's inventory. `remove_all_items *[target (player|'pinged'):<self>]`
 * **remove_equip** - Sets the equipment of a character to 'None'. `remove_equip *[target (player|'pinged'):<self>]`
-* **create_pickup** - Creates a pickup in front of the issuing player. Pickups are items, equipment, or lunar coins. Additionally 'item' or 'equip' may be specified to only search that list. `create_pickup {(object|'coin')} [search ('item'|'equip'):<both>]`
+* **create_pickup** - Creates a pickup in front of a player. Pickups are items, equipment, or lunar coins. Additionally 'item' or 'equip' may be specified to only search that list. `create_pickup {object (item|equip|'coin')} [search ('item'|'equip'):<both>] *[player:<self>]`
 
 Spawn Commands:
 
 * **spawn_interactable/spawn_interactible** - Spawns an interactible in front of the player. `(spawn_interactable|spawn_interactible) {interactable}`
 * **spawn_ai** - Spawn an AI. `spawn_ai {ai} [count:1] [elite:None] [braindead (0|1):0/false] [team:Monster]`.
-* **spawn_as** - Spawn as a new character. `spawn_as {body} [target player:<self>]`
+* **spawn_as** - Spawn as a new character. `spawn_as {body} *[player:<self>]`
 * **spawn_body** - Spawns a CharacterBody with no AI, inventory, or team alliance: `spawn_body {body}`
-* **change_team** - Change a player's team. `change_team {team} [target player:<self>]`.
+* **change_team** - Change a player's team. `change_team {team} *[player:<self>]`.
 
 Cheat Commands:
 


### PR DESCRIPTION
- Log a message if the command requires being in a run. This mostly applies while being in a lobby pregame. An edge case I haven't managed to address is being on the report screen, e.g., after dying, as it still counts being in a run, but a lot of the commands will fail with NPE or ArgumentOutOfRangeIndexException.
- Don't silently use the default value for an optional argument when parsing fails, but log a parsing error.
- Be explicit when a command has not been given enough arguments, e.g., `"Insufficient args" + Lang.RELEVANT_COMMAND_ARGS`.

Also gathered all the command help texts in Lang.cs for convenience.