### PR TITLE
Fix next_boss, Issue #88

### DIFF
--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -298,8 +298,10 @@ namespace DebugToolkit.Commands
 
             // Unsub the last in case the user already used the command and want to change their mind.
             On.RoR2.CombatDirector.SetNextSpawnAsBoss -= Hooks.CombatDirector_SetNextSpawnAsBoss;
+            On.RoR2.InfiniteTowerExplicitSpawnWaveController.Initialize -= Hooks.InfiniteTowerExplicitSpawnWaveController_Initialize;
 
             On.RoR2.CombatDirector.SetNextSpawnAsBoss += Hooks.CombatDirector_SetNextSpawnAsBoss;
+            On.RoR2.InfiniteTowerExplicitSpawnWaveController.Initialize += Hooks.InfiniteTowerExplicitSpawnWaveController_Initialize;
             Log.MessageNetworked(s.ToString(), args);
         }
 

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -166,10 +166,10 @@ namespace DebugToolkit.Commands
                 }
                 foreach (var elite in EliteCatalog.eliteDefs)
                 {
-                    var eliteName = Regex.Replace(elite.name, "^ed", "");
+                    var eliteName = elite.name;
                     if (int.TryParse(name, out iName) && i == iName || eliteName.ToUpper().Contains(name.ToUpper()))
                     {
-                        sb.AppendLine($"[{i}][{eliteName}");
+                        sb.AppendLine($"[{i}]{eliteName}");
                         resultCount++;
                     }
                     i++;
@@ -184,7 +184,7 @@ namespace DebugToolkit.Commands
                 sb.AppendLine("[-1]None");
                 foreach (var elite in EliteCatalog.eliteDefs)
                 {
-                    var eliteName = elite.name.Substring(2);
+                    var eliteName = elite.name;
                     sb.AppendLine($"[{i}]{eliteName}");
                     i++;
                 }

--- a/Code/DT-Commands/Spawners.cs
+++ b/Code/DT-Commands/Spawners.cs
@@ -201,17 +201,21 @@ namespace DebugToolkit.Commands
         }
 
 
-        internal static CombatDirector.EliteTierDef GetTierDef(EliteIndex index)
+        internal static CombatDirector.EliteTierDef GetTierDef(EliteDef eliteDef)
         {
+            if (!eliteDef)
+            {
+                return CombatDirector.eliteTiers[0];
+            }
             foreach (var eliteTier in CombatDirector.eliteTiers)
             {
                 if (eliteTier != null)
                 {
-                    foreach (var eliteDef in eliteTier.eliteTypes)
+                    foreach (var thisEliteDef in eliteTier.eliteTypes)
                     {
-                        if (eliteDef)
+                        if (thisEliteDef)
                         {
-                            if (eliteDef.eliteIndex == index)
+                            if (thisEliteDef == eliteDef)
                             {
                                 return eliteTier;
                             }

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -374,6 +374,24 @@ namespace DebugToolkit
             Log.Message($"The director credits have been set to {self.monsterCredit} to spawn {count} {eliteName} {selectedBossCard.spawnCard.name}", Log.LogLevel.Info);
 
             On.RoR2.CombatDirector.SetNextSpawnAsBoss -= CombatDirector_SetNextSpawnAsBoss;
+            On.RoR2.InfiniteTowerExplicitSpawnWaveController.Initialize -= InfiniteTowerExplicitSpawnWaveController_Initialize;
+        }
+
+        internal static void InfiniteTowerExplicitSpawnWaveController_Initialize(On.RoR2.InfiniteTowerExplicitSpawnWaveController.orig_Initialize orig, InfiniteTowerExplicitSpawnWaveController self, int waveIndex, Inventory enemyInventory, GameObject spawnTargetObject)
+        {
+            self.spawnList = new InfiniteTowerExplicitSpawnWaveController.SpawnInfo[]
+            {
+                new InfiniteTowerExplicitSpawnWaveController.SpawnInfo
+                {
+                    spawnCard = (CharacterSpawnCard)CurrentRun.nextBoss.spawnCard,
+                    eliteDef = CurrentRun.nextBossElite,
+                    count = CurrentRun.nextBossCount
+                }
+            };
+            orig(self, waveIndex, enemyInventory, spawnTargetObject);
+
+            On.RoR2.CombatDirector.SetNextSpawnAsBoss -= CombatDirector_SetNextSpawnAsBoss;
+            On.RoR2.InfiniteTowerExplicitSpawnWaveController.Initialize -= InfiniteTowerExplicitSpawnWaveController_Initialize;
         }
 
         internal static void SeedHook(On.RoR2.PreGameController.orig_Awake orig, PreGameController self)

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -365,32 +365,8 @@ namespace DebugToolkit
 
             var selectedElite = CurrentRun.nextBossElite;
             self.currentActiveEliteDef = selectedElite;
-            var eliteName = "non-elite";
-            if (selectedElite == null)
-            {
-                self.currentActiveEliteTier = CombatDirector.eliteTiers[0];
-            }
-            else
-            {
-                eliteName = selectedElite.name;
-                var found = false;
-                foreach (var eliteTier in CombatDirector.eliteTiers)
-                {
-                    foreach (var eliteDef in eliteTier.eliteTypes)
-                    {
-                        if (eliteDef == CurrentRun.nextBossElite)
-                        {
-                            self.currentActiveEliteTier = eliteTier;
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (found)
-                    {
-                        break;
-                    }
-                }
-            }
+            self.currentActiveEliteTier = Spawners.GetTierDef(selectedElite);
+            var eliteName = (selectedElite == null) ? "non-elite" : selectedElite.name;
 
             var count = CurrentRun.nextBossCount;
             self.monsterCredit = selectedBossCard.cost * count * self.currentActiveEliteTier.costMultiplier;

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -86,7 +86,7 @@
             MACRO_DTZOOM_HELP = "Gives you 20 hooves and 200 feathers for getting around quickly.",
             MACRO_LATEGAME_HELP = "Sets the current run to the 'lategame' as defined by HG. This command is DESTRUCTIVE.",
             MACRO_MIDGAME_HELP = "Sets the current run to the 'midgame' as defined by HG. This command is DESTRUCTIVE.",
-            NEXTBOSS_HELP = "Sets the next teleporter instance to the specified boss. " + NEXTBOSS_ARGS,
+            NEXTBOSS_HELP = "Sets the next teleporter/simulacrum boss to the specified boss. " + NEXTBOSS_ARGS,
             NEXTSTAGE_HELP = "Forces a stage change to the specified stage. " + NEXTSTAGE_ARGS,
             NOCLIP_HELP = "Allow flying and going through objects. Sprinting will double the speed. " + NO_ARGS,
             NOENEMIES_HELP = "Toggle Monster spawning. " + NO_ARGS,

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -463,6 +463,39 @@ namespace DebugToolkit
             return SkinIndex.None;
         }
 
+        /// <summary>
+        /// Returns an EliteIndex when provided with a partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches in order: (int)Index, Partial Invariant</param>
+        /// <returns>Returns the EliteIndex if a match is found including EliteIndex.None, or returns -2</returns>
+        public EliteIndex GetEliteFromPartial(string name)
+        {
+            if (int.TryParse(name, out int index))
+            {
+                if (index == -1)
+                {
+                    return (EliteIndex)(-1);
+                }
+                else if (EliteCatalog.GetEliteDef((EliteIndex)index) != null)
+                {
+                    return (EliteIndex)index;
+                }
+            }
+
+            if ("NONE".Contains(name.ToUpper()))
+            {
+                return (EliteIndex)(-1);
+            }
+            foreach (var elite in EliteCatalog.eliteDefs)
+            {
+                if (elite.name.ToUpper().Contains(name.ToUpper()))
+                {
+                    return elite.eliteIndex;
+                }
+            }
+            return (EliteIndex)(-2);
+        }
+
         public DirectorCard GetDirectorCardFromPartial(string masterNameUpper)
         {
             var nameUpper = masterNameUpper.ToUpperInvariant();

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -482,13 +482,13 @@ namespace DebugToolkit
                 }
             }
 
-            if ("NONE".Contains(name.ToUpper()))
+            if ("NONE".Contains(name.ToUpperInvariant()))
             {
                 return (EliteIndex)(-1);
             }
             foreach (var elite in EliteCatalog.eliteDefs)
             {
-                if (elite.name.ToUpper().Contains(name.ToUpper()))
+                if (elite.name.ToUpperInvariant().Contains(name.ToUpperInvariant()))
                 {
                     return elite.eliteIndex;
                 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Commands:
 
 * **next_stage** - Advance to the next stage. `next_stage [specific_stage]`. If no stage is entered, the next stage in progression is selected.
 * **force_family_event** - Forces a Family Event to happen in the next stage, takes no arguments. `force_family_event`
-* **next_boss** - Sets the teleporter boss to the specified boss. Get a list of potential boss with `list_directorcards`. `next_boss {director_card} [count:1] [elite:None]`
+* **next_boss** - Sets the next teleporter/simulacrum boss to the specified boss. Get a list of potential boss with `list_directorcards`. `next_boss {director_card} [count:1] [elite:None]`
 * **fixed_time** - Sets the time that has progressed in the run. Affects difficulty. `fixed_time [time]`. If no time is supplied, prints the current time to console.
 * **add_portal** - Teleporter will attempt to spawn after the teleporter completion. `add_portal {portal ('blue'|'gold'|'celestial'|'null'|'void'|'deepvoid'|'all')}`. The `null` portal doesn't require a teleporter and will spawn in front of the player.
 * **seed** - Set the seed for all next runs this session. `seed [new_seed]`. Use `0` to specify the game should generate its own seed. If used without argument, it's equivalent to the vanilla `run_get_seed`.


### PR DESCRIPTION
Addresses fixes mentioned in the aformentioned issue.

I partially touched the `spawn_ai` command as well, since the elite parsing problem also exists there and I took the opportunity to move any argument parsing outside of the loop for spawning monsters.

The SetNextSpawnAsBoss hook may feel a bit inconsistent at the moment, as it is triggered for the teleporter and some of the simulacrum waves. The options are:
- we leave it as it is since people are "expected" to understand mithrix/scav use a different mechanism
- we remove the hook for simulacrum waves in general and keep it strictly for the teleporter
- we also add a hook for the InfiniteTowerExplicitSpawnWaveController

Overriding a lunar boss wave to spawn, say, gups, works, but the drop is still linked to the wave controller. I reckon this is a non-issue, as we're only trying to override the boss.

---
I added the method `GetEliteFromPartial`, but not its array counterpart. To be frank, this whole `GetXFromPartial` is starting to smell to me. A lot of code duplication between the two versions and the `list_` commands sometimes do the same amount of work, too. I'm starting to think that we only need the array version of `GetXFromPartial`. If the result is empty, we handle it as an error; no need for unnatural (EliteIndex)(-2) or Equipment.None. Else we either get the first result or all, depending on what we're doing. The `list_` commands can then only focus on how to format the fetched results.

This is an issue for a separate PR, but I'm justifying why I didn't add `GetElitesFromPartial`: it works for the current fix and I expect this will be revisited.