### PR TITLE
Change command: create_pickup

### DIFF
--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -393,7 +393,7 @@ namespace DebugToolkit.Commands
             {
                 switch (args[1].ToUpperInvariant())
                 {
-                    case Lang.ALL:
+                    case Lang.BOTH:
                         break;
                     case Lang.ITEM:
                         searchEquip = false;

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -300,20 +300,21 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            var equip = StringFinder.Instance.GetEquipFromPartial(args[0]);
-            if (equip != EquipmentIndex.None)
-            {
-                inventory.SetEquipmentIndex(equip);
-            }
-            else if (args[0].ToUpper() == Lang.RANDOM)
+            var equip = EquipmentIndex.None;
+            if (args[0].ToUpperInvariant() == Lang.RANDOM)
             {
                 inventory.GiveRandomEquipment();
                 equip = inventory.GetEquipmentIndex();
             }
             else
             {
-                Log.MessageNetworked(Lang.OBJECT_NOTFOUND + args[0] + ":" + equip, args, LogLevel.MessageClientOnly);
-                return;
+                equip = StringFinder.Instance.GetEquipFromPartial(args[0]);
+                if (equip == EquipmentIndex.None)
+                {
+                    Log.MessageNetworked(Lang.OBJECT_NOTFOUND + args[0] + ":" + equip, args, LogLevel.MessageClientOnly);
+                    return;
+                }
+                inventory.SetEquipmentIndex(equip);
             }
 
             Log.MessageNetworked($"Gave {equip} to {targetName}", args);
@@ -355,6 +356,8 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "create_pickup", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.CREATEPICKUP_HELP)]
+        [AutoCompletion(typeof(EquipmentCatalog), "equipmentDefs", "nameToken")]
+        [AutoCompletion(typeof(ItemCatalog), "itemDefs", "nameToken")]
         private static void CCCreatePickup(ConCommandArgs args)
         {
             if (!Run.instance)
@@ -388,8 +391,10 @@ namespace DebugToolkit.Commands
             bool searchEquip = true, searchItem = true;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
             {
-                switch (args[1].ToUpper())
+                switch (args[1].ToUpperInvariant())
                 {
+                    case Lang.ALL:
+                        break;
                     case Lang.ITEM:
                         searchEquip = false;
                         break;
@@ -405,34 +410,44 @@ namespace DebugToolkit.Commands
             EquipmentIndex equipment = EquipmentIndex.None;
             ItemIndex item = ItemIndex.None;
 
-            if (searchEquip)
+            switch (args[0].ToUpperInvariant())
             {
-                equipment = StringFinder.Instance.GetEquipFromPartial(args[0]);
-                final = PickupCatalog.FindPickupIndex(equipment);
-            }
-            if (searchItem)
-            {
-                item = StringFinder.Instance.GetItemFromPartial(args[0]);
-                final = PickupCatalog.FindPickupIndex(item);
-            }
-            if (item != ItemIndex.None && equipment != EquipmentIndex.None)
-            {
-                Log.MessageNetworked(string.Format(Lang.CREATEPICKUP_AMBIGIOUS_2, item, equipment), args, LogLevel.MessageClientOnly);
-                return;
+                case Lang.COIN_LUNAR:
+                    final = PickupCatalog.FindPickupIndex("LunarCoin.Coin0");
+                    break;
+                case Lang.COIN_VOID:
+                    final = PickupCatalog.FindPickupIndex("MiscPickupIndex.VoidCoin");
+                    break;
+                default:
+                    if (searchEquip)
+                    {
+                        equipment = StringFinder.Instance.GetEquipFromPartial(args[0]);
+                    }
+                    if (searchItem)
+                    {
+                        item = StringFinder.Instance.GetItemFromPartial(args[0]);
+                    }
+                    if (item == ItemIndex.None && equipment == EquipmentIndex.None)
+                    {
+                        Log.MessageNetworked(Lang.CREATEPICKUP_NOTFOUND, args, LogLevel.MessageClientOnly);
+                        return;
+                    }
+                    else if (item != ItemIndex.None && equipment != EquipmentIndex.None)
+                    {
+                        Log.MessageNetworked(string.Format(Lang.CREATEPICKUP_AMBIGIOUS_2, item, equipment), args, LogLevel.MessageClientOnly);
+                        return;
+                    }
+                    else if (equipment != EquipmentIndex.None)
+                    {
+                        final = PickupCatalog.FindPickupIndex(equipment);
+                    }
+                    else
+                    {
+                        final = PickupCatalog.FindPickupIndex(item);
+                    }
+                    break;
             }
 
-            if (item == ItemIndex.None && equipment == EquipmentIndex.None)
-            {
-                if (args[0].ToUpper() == Lang.COIN)
-                {
-                    final = PickupCatalog.FindPickupIndex("LunarCoin.Coin0");
-                }
-                else
-                {
-                    Log.MessageNetworked(Lang.CREATEPICKUP_NOTFOUND, args, LogLevel.MessageClientOnly);
-                    return;
-                }
-            }
             Log.MessageNetworked(string.Format(Lang.CREATEPICKUP_SUCCES_1, final), args);
             PickupDropletController.CreatePickupDroplet(final, transform.position, transform.forward * 40f);
         }

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -11,7 +11,7 @@
             BIND_ARGS = "Requires 2 arguments: {key} {console_commands}",
             BIND_DELETE_ARGS = "Requires 1 argument: {key}",
             CHANGETEAM_ARGS = "Requires 1 (2 if from server) argument: {team} [player]",
-            CREATEPICKUP_ARGS = "Requires 1 (3 if from server) argument: {object (item|equip|'coin')} [search ('item'|'equip'):<both>] [player:<self>]",
+            CREATEPICKUP_ARGS = "Requires 1 (3 if from server) argument: {object (item|equip|'lunarcoin'|'voidcoin')} [search ('item'|'equip'|'all'):'all'] *[player:<self>]",
             FIXEDTIME_ARGS = "Requires 0 or 1 argument: [time]",
             GIVEBUFF_ARGS = "Requires 1 (4 if from server) arguments: {buff} [count:1] [duration:0] [target (player|'pinged'):<self>]",
             GIVEDOT_ARGS = "Requires 1 (4 if from server) argument: {dot} [count:1] [target (player|'pinged'):<self>] [attacker (player|'pinged'):<self>]",
@@ -120,7 +120,7 @@
         // Messages
         public const string
             CREATEPICKUP_AMBIGIOUS_2 = "Could not choose between {0} and {1}, please be more precise. Consider using 'equip' or 'item' as the second argument.",
-            CREATEPICKUP_NOTFOUND = "Could not find any item nor equipment with that name. It's not a coin either.",
+            CREATEPICKUP_NOTFOUND = "Could not find any item nor equipment with that name.",
             CREATEPICKUP_SUCCES_1 = "Succesfully created the pickup {0}.",
             GIVELUNAR_2 = "{0} {1} lunar coin(s).",
             GIVEOBJECT = "Gave {0} {1}",
@@ -160,7 +160,8 @@
         // Keywords
         public const string
             ALL = "ALL",
-            COIN = "COIN",
+            COIN_LUNAR = "LUNARCOIN",
+            COIN_VOID = "VOIDCOIN",
             DEFAULT_VALUE = "",
             EQUIP = "EQUIP",
             ITEM = "ITEM",

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -11,7 +11,7 @@
             BIND_ARGS = "Requires 2 arguments: {key} {console_commands}",
             BIND_DELETE_ARGS = "Requires 1 argument: {key}",
             CHANGETEAM_ARGS = "Requires 1 (2 if from server) argument: {team} [player]",
-            CREATEPICKUP_ARGS = "Requires 1 (3 if from server) argument: {object (item|equip|'lunarcoin'|'voidcoin')} [search ('item'|'equip'|'all'):'all'] *[player:<self>]",
+            CREATEPICKUP_ARGS = "Requires 1 (3 if from server) argument: {object (item|equip|'lunarcoin'|'voidcoin')} [search ('item'|'equip'|'both'):'both'] *[player:<self>]",
             FIXEDTIME_ARGS = "Requires 0 or 1 argument: [time]",
             GIVEBUFF_ARGS = "Requires 1 (4 if from server) arguments: {buff} [count:1] [duration:0] [target (player|'pinged'):<self>]",
             GIVEDOT_ARGS = "Requires 1 (4 if from server) argument: {dot} [count:1] [target (player|'pinged'):<self>] [attacker (player|'pinged'):<self>]",
@@ -160,6 +160,7 @@
         // Keywords
         public const string
             ALL = "ALL",
+            BOTH = "BOTH",
             COIN_LUNAR = "LUNARCOIN",
             COIN_VOID = "VOIDCOIN",
             DEFAULT_VALUE = "",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Item Commands:
 * **remove_item_stacks** - Removes all item stacks from a character's inventory. `remove_item_stacks {item} *[target (player|'pinged'):<self>]`
 * **remove_all_items** - Removes all items from a character's inventory. `remove_all_items *[target (player|'pinged'):<self>]`
 * **remove_equip** - Sets the equipment of a character to 'None'. `remove_equip *[target (player|'pinged'):<self>]`
-* **create_pickup** - Creates a pickup in front of a player. Pickups are items, equipment, or lunar coins. Additionally 'item' or 'equip' may be specified to only search that list. `create_pickup {object (item|equip|'lunarcoin'|'voidcoin')} [search ('item'|'equip'|'all'):'all'] *[player:<self>]`
+* **create_pickup** - Creates a pickup in front of a player. Pickups are items, equipment, or coins. When the pickup is an item or equipment, the search argument 'item' or 'equip' may be specified to only search that list. `create_pickup {object (item|equip|'lunarcoin'|'voidcoin')} [search ('item'|'equip'|'both'):'both'] *[player:<self>]`
 
 Spawn Commands:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Item Commands:
 * **remove_item_stacks** - Removes all item stacks from a character's inventory. `remove_item_stacks {item} *[target (player|'pinged'):<self>]`
 * **remove_all_items** - Removes all items from a character's inventory. `remove_all_items *[target (player|'pinged'):<self>]`
 * **remove_equip** - Sets the equipment of a character to 'None'. `remove_equip *[target (player|'pinged'):<self>]`
-* **create_pickup** - Creates a pickup in front of a player. Pickups are items, equipment, or lunar coins. Additionally 'item' or 'equip' may be specified to only search that list. `create_pickup {object (item|equip|'coin')} [search ('item'|'equip'):<both>] *[player:<self>]`
+* **create_pickup** - Creates a pickup in front of a player. Pickups are items, equipment, or lunar coins. Additionally 'item' or 'equip' may be specified to only search that list. `create_pickup {object (item|equip|'lunarcoin'|'voidcoin')} [search ('item'|'equip'|'all'):'all'] *[player:<self>]`
 
 Spawn Commands:
 


### PR DESCRIPTION
* Add autocomplete support, fix equipment not found without the 'equip' search. Fixes #109
* Add void coin support; useful for the Released From The Void mod.
* Explicit arg strings should be prioritised before partial search terms to avoid ambiguity.
   *  The same applies to `give_equip {equip|'random'}`, so I fixed that too.