### PR TITLE
Fix Command: "spawn_interactable"

### DIFF
--- a/Code/DT-Commands/Spawners.cs
+++ b/Code/DT-Commands/Spawners.cs
@@ -1,13 +1,9 @@
 ﻿using RoR2;
 using RoR2.CharacterAI;
 using System;
-using System.Globalization;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
-using UnityEngine.UIElements;
 using static DebugToolkit.Log;
-using static RoR2.DirectorPlacementRule;
 
 namespace DebugToolkit.Commands
 {

--- a/Code/DT-Commands/Spawners.cs
+++ b/Code/DT-Commands/Spawners.cs
@@ -5,7 +5,9 @@ using System.Globalization;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
+using UnityEngine.UIElements;
 using static DebugToolkit.Log;
+using static RoR2.DirectorPlacementRule;
 
 namespace DebugToolkit.Commands
 {
@@ -42,9 +44,9 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.INTERACTABLE_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            var result = isc.DoSpawn(args.senderBody.transform.position, new Quaternion(), new DirectorSpawnRequest(
+            var result = isc.DoSpawn(args.senderBody.footPosition, new Quaternion(), new DirectorSpawnRequest(
                 isc,
-                new DirectorPlacementRule
+                new DirectorPlacementRule  // unused internally
                 {
                     placementMode = DirectorPlacementRule.PlacementMode.NearestNode,
                     maxDistance = 100f,


### PR DESCRIPTION
**Issue**
Spawned interactables float a little bit over the ground. (Issue #140)

**Solution**
The call `isc.DoSpawn(position, rotation, spawnRequest)` does not use the request for placing the object to the nearest node. Instead, we need to rely on the player's foot position directly.