### PR TITLE
Fix "midgame" and "lategame" commands. Closes #143

### DIFF
--- a/Code/DT-Commands/Macros.cs
+++ b/Code/DT-Commands/Macros.cs
@@ -14,7 +14,7 @@ namespace DebugToolkit.Commands
             foreach (NetworkUser user in NetworkUser.readOnlyInstancesList)
             {
                 Invoke(a, "remove_all_items", user.userName);
-                Invoke(a, "random_items", "23", user.userName);
+                Invoke(a, "random_items", "23", "Tier1,Tier2,Tier3", user.userName);
                 Invoke(a, "give_equip", "random", user.userName);
             }
             Invoke(a, "set_scene", "bazaar");
@@ -30,7 +30,7 @@ namespace DebugToolkit.Commands
             foreach (NetworkUser user in NetworkUser.readOnlyInstancesList)
             {
                 Invoke(a, "remove_all_items", user.userName);
-                Invoke(a, "random_items", "75", user.userName);
+                Invoke(a, "random_items", "75", "Tier1,Tier2,Tier3", user.userName);
                 Invoke(a, "give_equip", "random", user.userName);
             }
             Invoke(a, "set_scene", "bazaar");


### PR DESCRIPTION
The previous update changed the command signature for `random_items` to include tiers. This change properly updates the macro commands to account for this.