### PR TITLE
Fix force_family_event edge cases

### DIFF
--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -233,10 +233,9 @@ namespace DebugToolkit.Commands
         [ConCommand(commandName = "force_family_event", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.FAMILYEVENT_HELP)]
         private static void CCFamilyEvent(ConCommandArgs args)
         {
-            On.RoR2.DccsPool.GenerateWeightedSelection += Hooks.ForceFamilyEventForDccsPoolStages;
-            On.RoR2.ClassicStageInfo.RebuildCards += Hooks.ForceFamilyEventForNonDccsPoolStages;
-
-            Log.MessageNetworked("The next stage will contain a family event!", args);
+            On.RoR2.ClassicStageInfo.RebuildCards -= Hooks.ForceFamilyEvent;
+            On.RoR2.ClassicStageInfo.RebuildCards += Hooks.ForceFamilyEvent;
+            Log.MessageNetworked("The next stage will contain a family event if available!", args);
         }
 
         [ConCommand(commandName = "next_boss", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.NEXTBOSS_HELP)]


### PR DESCRIPTION
1. Multiple command calls shouldn't stack the hooks.
2. If a stage has no family dccs, e.g., limbo, the dccs-hook returns an empty selection which causes an error for `Evaluate()`. It should instead return the original selection.
3. The dccs- and nondccs-hooks can become desynced. R2API.Director ensures that all stages use the new api, but if someone sets the dccs pool to null, the nondccs hook will be consumed on the next stage, but the dccs on the stage after that. Both hooks/patches should be applied and unapplied from the same method to avoid this.
4. The nondccs-hook is insufficient to ensure family events with the old api. On top of ensuring the family event chance is 100%, it also requires the family categories to lift their stage restrictions.

The only loophole left is a dccs pool existing but not yielding any family events, e.g., limbo with the default R2API pool and a modder assigning the family events with the old api, or someone removing the family events from, for example, golemplains. In that case the command won't fall back to finding a family from the old api. I think this is fine because as long as a pool exists, it should only use that. And if someone intentionally removes the family events and wants to test the result, they will be very surprised if an event still occurs due to a fallback mechanism.