### PR TITLE
change give_money to support negative amounts

### DIFF
--- a/Code/DT-Commands/Money.cs
+++ b/Code/DT-Commands/Money.cs
@@ -1,5 +1,8 @@
 ﻿using RoR2;
+using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using UnityEngine;
 using static DebugToolkit.Log;
 
 namespace DebugToolkit.Commands
@@ -20,9 +23,9 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            if (!TextSerialization.TryParseInvariant(args[0], out uint result))
+            if (!TextSerialization.TryParseInvariant(args[0], out int result))
             {
-                Log.MessageNetworked(string.Format(Lang.PARSE_ERROR, "amount", "uint"), args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(string.Format(Lang.PARSE_ERROR, "amount", "int"), args, LogLevel.MessageClientOnly);
                 return;
             }
 
@@ -31,61 +34,71 @@ namespace DebugToolkit.Commands
                 if (UseShareSuite())
                 {
                     ShareSuiteGive(result);
+                    return;
                 }
             }
 
-            if (args.sender != null && args.Count < 2 || args[1].ToUpper() != Lang.ALL || args[1].ToUpper() != Lang.DEFAULT_VALUE)
+            if (args.Count > 1 && args[1].ToUpperInvariant() != Lang.ALL && args[1].ToUpperInvariant() != Lang.DEFAULT_VALUE)
             {
-                CharacterMaster master = args.sender?.master;
-                if (args.Count >= 2)
+                NetworkUser player = Util.GetNetUserFromString(args.userArgs, 1);
+                if (player != null)
                 {
-                    NetworkUser player = Util.GetNetUserFromString(args.userArgs, 1);
-                    if (player != null)
-                    {
-                        master = player.master;
-                    }
-                    else if (args.sender == null)
-                    {
-                        Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
-                        return;
-                    }
-                }
-
-                if (master)
-                {
-                    master.GiveMoney(result);
+                    GiveMasterMoney(player.master, result);
                 }
                 else
                 {
-                    Log.MessageNetworked("Error: Master was null", args, LogLevel.MessageClientOnly);
+                    Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
                 }
             }
             else
             {
-                if (args.sender != null)
-                {
-                    TeamManager.instance.GiveTeamMoney(args.sender.master.teamIndex, result);
-                }
-                else
-                {
-                    TeamManager.instance.GiveTeamMoney(TeamIndex.Player, result);
-                }
+                var teamIndex = args.senderMaster == null ? TeamIndex.Player : args.senderMaster.teamIndex;
+                GiveTeamMoney(teamIndex, result);
             }
 
             Log.MessageNetworked("$$$", args);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        private static void ShareSuiteGive(uint amount)
+        private static void GiveMasterMoney(CharacterMaster master, int amount)
         {
-            ShareSuite.MoneySharingHooks.AddMoneyExternal((int)amount);
+            master.money = (uint)Math.Max(0, master.money + amount);
+        }
+
+        private static void GiveTeamMoney(TeamIndex teamIndex, int money)
+        {
+            var players = new List<CharacterMaster>();
+            foreach (var member in TeamComponent.GetTeamMembers(teamIndex))
+            {
+                var body = member.body;
+                if (body && body.isPlayerControlled && body.master)
+                {
+                    players.Add(body.master);
+                }
+            }
+            int num = players.Count;
+            if (num != 0)
+            {
+                money = Mathf.CeilToInt(money / (float)num);
+                foreach (var master in players)
+                {
+                    GiveMasterMoney(master, money);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        private static void ShareSuiteGive(int amount)
+        {
+            var moneyPool = ShareSuite.MoneySharingHooks.SharedMoneyValue;
+            amount = Math.Max(-moneyPool, amount);
+            ShareSuite.MoneySharingHooks.AddMoneyExternal(amount);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         private static bool UseShareSuite()
         {
-            return ShareSuite.ShareSuite.MoneyIsShared.Value;
+            return ShareSuite.ShareSuite.MoneyIsShared.Value && ShareSuite.GeneralHooks.IsMultiplayer();
         }
     }
 }


### PR DESCRIPTION
Closes #144

- Reinvent `GiveMoney` and `GiveTeamMoney` to not allow the resulting money to underflow.
- The `UseShareSuite` check needs to also account for multiplayer.
- Fixed a logic bug in checking for the target of the receiver. Now a dedicated server can successfully award a specific player instead of always defaulting to the whole team.