### PR TITLE
Fix noclip issues

### DIFF
--- a/Code/DT-Commands/Command_Noclip.cs
+++ b/Code/DT-Commands/Command_Noclip.cs
@@ -52,7 +52,7 @@ namespace DebugToolkit.Commands
                     }
                     if (motor)
                     {
-                        _currentBody.characterMotor.SetUseGravity(true);
+                        motor.useGravity = motor.gravityParameters.CheckShouldUseGravity();
                     }
                     UndoHooks();
                 }
@@ -72,7 +72,7 @@ namespace DebugToolkit.Commands
                     }
                     if (motor)
                     {
-                        motor.SetUseGravity(false);
+                        motor.useGravity = false;
                     }
                     ApplyHooks();
                 }
@@ -194,7 +194,11 @@ namespace DebugToolkit.Commands
                     {
                         kcm.RebuildCollidableLayers();
                     }
-                    _currentBody.characterMotor.SetUseGravity(!_currentBody.characterMotor.useGravity);
+                    var motor = _currentBody.characterMotor;
+                    if (motor)
+                    {
+                        motor.useGravity = motor.gravityParameters.CheckShouldUseGravity();
+                    }
                 }
 
                 UndoHooks();

--- a/Code/DT-Commands/Command_Noclip.cs
+++ b/Code/DT-Commands/Command_Noclip.cs
@@ -115,10 +115,13 @@ namespace DebugToolkit.Commands
         {
             var kcm = _currentBody.GetComponent<KinematicCharacterMotor>();
             var rigid = _currentBody.GetComponent<Rigidbody>();
-            if (kcm && kcm.CollidableLayers != 0) // when respawning or things like that, call the toggle to set the variables correctly again
+            if (kcm) // when respawning or things like that, call the toggle to set the variables correctly again
             {
-                InternalToggle();
-                InternalToggle();
+                if (kcm.CollidableLayers != 0)
+                {
+                    InternalToggle();
+                    InternalToggle();
+                }
             }
             else if (rigid)
             {

--- a/Code/DT-Commands/Command_Noclip.cs
+++ b/Code/DT-Commands/Command_Noclip.cs
@@ -150,8 +150,8 @@ namespace DebugToolkit.Commands
                     _currentBody.characterMotor.SetUseGravity(!_currentBody.characterMotor.useGravity);
                 }
 
-                IsActivated = !IsActivated;
                 UndoHooks();
+                IsActivated = !IsActivated;
                 Log.Message(string.Format(Lang.NOCLIP_TOGGLE, IsActivated));
             }
 


### PR DESCRIPTION
Fixes #160

The command did not null check for components it needed access to. As such it would throw for flyers. The checks themselves wouldn't make it functional for flyers, which require turning off collisions from the entity's collider directly and modifying the rigid body's velocity in a similar manner to the character motor.

Incidentally, by checking for `collidableLayers != 0` fixes another bug where the imp overlord and merc would have their layers rebuilt after blinking/dashing. For that reason it's also cleaner to not cache the layers but allow the game to rebuild them, since the entity states related to the aforementioned skills change the character's layer for both entering and exiting the state.

The gravity bug blindly turned gravity off when noclip was disabled instead of checking whether gravity should be on/off based on environmental context.