### PR TITLE
Refactor stringfinder partial matching methods and normalise list commands

### DIFF
--- a/Code/DT-Commands/Buffs.cs
+++ b/Code/DT-Commands/Buffs.cs
@@ -1,7 +1,6 @@
 ﻿using RoR2;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using UnityEngine;
 using static DebugToolkit.Log;
@@ -14,43 +13,29 @@ namespace DebugToolkit.Commands
         private static void CCListBuff(ConCommandArgs args)
         {
             var sb = new StringBuilder();
-            IEnumerable<BuffIndex> buffList;
-            if (args.Count > 0)
+            var arg = args.Count > 0 ? args[0] : "";
+            var indices = StringFinder.Instance.GetBuffsFromPartial(arg);
+            foreach (var index in indices)
             {
-                buffList = (IEnumerable<BuffIndex>)StringFinder.Instance.GetBuffsFromPartial(args.GetArgString(0));
-                if (buffList.Count() == 0) sb.AppendLine($"No buff that matches \"{args[0]}\".");
+                var buff = BuffCatalog.GetBuffDef(index);
+                sb.AppendLine($"[{(int)index}]{buff.name} (stackable={buff.canStack})");
             }
-            else
-            {
-                buffList = (IEnumerable<BuffIndex>)BuffCatalog.buffDefs.Select(b => b.buffIndex);
-            }
-            foreach (var buffIndex in buffList)
-            {
-                var definition = BuffCatalog.GetBuffDef(buffIndex);
-                sb.AppendLine($"[{(int)buffIndex}]{definition.name} (stackable={definition.canStack})");
-            }
-            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
+            var s = sb.Length > 0 ? sb.ToString().TrimEnd('\n') : string.Format(Lang.NOMATCH_ERROR, "buffs", arg);
+            Log.MessageNetworked(s, args, LogLevel.MessageClientOnly);
         }
 
         [ConCommand(commandName = "list_dot", flags = ConVarFlags.None, helpText = Lang.LISTDOT_HELP)]
         private static void CCListDot(ConCommandArgs args)
         {
             var sb = new StringBuilder();
-            IEnumerable<DotController.DotIndex> dotList;
-            if (args.Count > 0)
+            var arg = args.Count > 0 ? args[0] : "";
+            var indices = StringFinder.Instance.GetDotsFromPartial(arg);
+            foreach (var index in indices)
             {
-                dotList = (IEnumerable<DotController.DotIndex>)StringFinder.Instance.GetDotsFromPartial(args.GetArgString(0));
-                if (dotList.Count() == 0) sb.AppendLine($"No DoT that matches \"{args[0]}\".");
+                sb.AppendLine($"[{(int)index}]{index}");
             }
-            else
-            {
-                dotList = (IEnumerable<DotController.DotIndex>)Enum.GetValues(typeof(DotController.DotIndex)).Cast<DotController.DotIndex>().Where(d => d >= DotController.DotIndex.Bleed && d < DotController.DotIndex.Count);
-            }
-            foreach (var dotIndex in dotList)
-            {
-                sb.AppendLine($"[{(int)dotIndex}]{dotIndex}");
-            }
-            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
+            var s = sb.Length > 0 ? sb.ToString().TrimEnd('\n') : string.Format(Lang.NOMATCH_ERROR, "DoT", arg);
+            Log.MessageNetworked(s, args, LogLevel.MessageClientOnly);
         }
 
         [ConCommand(commandName = "dump_buffs", flags = ConVarFlags.None, helpText = Lang.DUMPBUFFS_HELP)]

--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -2,7 +2,6 @@ using R2API.Utils;
 using RoR2;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -190,23 +189,24 @@ namespace DebugToolkit.Commands
                 return;
             }
             TeamIndex team = TeamIndex.Monster;
-            if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE && !StringFinder.TryGetEnumFromPartial(args[0], out team))
+            if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
-                Log.MessageNetworked(Lang.TEAM_NOTFOUND, args, LogLevel.MessageClientOnly);
-                return;
+                team = StringFinder.Instance.GetTeamFromPartial(args[0]);
+                if (team == StringFinder.TeamIndex_NotFound)
+                {
+                    Log.MessageNetworked(Lang.TEAM_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
 
             int count = 0;
-            foreach (CharacterMaster cm in UnityEngine.Object.FindObjectsOfType<CharacterMaster>())
+            foreach (var teamComponent in TeamComponent.GetTeamMembers(team))
             {
-                if (cm.teamIndex == team)
+                var healthComponent = teamComponent.GetComponent<HealthComponent>();
+                if (healthComponent)
                 {
-                    CharacterBody cb = cm.GetBody();
-                    if (cb && cb.healthComponent)
-                    {
-                        cb.healthComponent.Suicide(null);
-                        count++;
-                    }
+                    healthComponent.Suicide(null);
+                    count++;
                 }
             }
             Log.MessageNetworked($"Killed {count} of team {team}.", args);
@@ -284,7 +284,7 @@ namespace DebugToolkit.Commands
             if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
                 var eliteIndex = StringFinder.Instance.GetEliteFromPartial(args[2]);
-                if ((int)eliteIndex == -2)
+                if (eliteIndex == StringFinder.EliteIndex_NotFound)
                 {
                     Log.MessageNetworked(Lang.ELITE_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;

--- a/Code/DT-Commands/DEBUG.cs
+++ b/Code/DT-Commands/DEBUG.cs
@@ -27,10 +27,10 @@ namespace DebugToolkit.Commands
             Log.Message(StringFinder.Instance.GetItemFromPartial(args[0]).ToString());
         }
 
-        [ConCommand(commandName = "getBodyName", flags = ConVarFlags.None, helpText = "Match a bpartial localised body name to a character body name")]
+        [ConCommand(commandName = "getBodyName", flags = ConVarFlags.None, helpText = "Match a partial localised body name to a character body name")]
         private static void CCGetBodyName(ConCommandArgs args)
         {
-            Log.Message(StringFinder.Instance.GetBodyName(args[0]));
+            Log.Message(StringFinder.Instance.GetBodyFromPartial(args[0]));
         }
 
         [ConCommand(commandName = "getEquipName", flags = ConVarFlags.None, helpText = "Match a partial localised equip name to an EquipIndex")]
@@ -42,7 +42,7 @@ namespace DebugToolkit.Commands
         [ConCommand(commandName = "getMasterName", flags = ConVarFlags.None, helpText = "Match a partial localised Master name to a CharacterMaster")]
         private static void CCGetMasterName(ConCommandArgs args)
         {
-            Log.Message(StringFinder.Instance.GetMasterName(args[0]));
+            Log.Message(StringFinder.Instance.GetAiFromPartial(args[0]));
         }
 
         [ConCommand(commandName = "getTeamIndexPartial", flags = ConVarFlags.None, helpText = "Match a partial TeamIndex")]

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -663,7 +663,7 @@ namespace DebugToolkit.Commands
                 {
                     var data = tierData.Split(':');
                     var itemTier = StringFinder.Instance.GetItemTierFromPartial(data[0]);
-                    if (itemTier == (ItemTier)(-1))
+                    if (itemTier == StringFinder.ItemTier_NotFound)
                     {
                         Log.MessageNetworked(Lang.OBJECT_NOTFOUND + data[0], args, LogLevel.MessageClientOnly);
                         return null;

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -2,7 +2,6 @@
 using RoR2.Artifacts;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -20,78 +19,48 @@ namespace DebugToolkit.Commands
         private static void CCListItemTier(ConCommandArgs args)
         {
             var sb = new StringBuilder();
-            IEnumerable<ItemTier> tierList;
-            if (args.Count > 0)
+            var arg = args.Count > 0 ? args[0] : "";
+            var indices = StringFinder.Instance.GetItemTiersFromPartial(arg);
+            foreach (var index in indices)
             {
-                tierList = (IEnumerable<ItemTier>)StringFinder.Instance.GetItemTiersFromPartial(args.GetArgString(0));
-                if (tierList.Count() == 0) sb.AppendLine($"No item tier that matches \"{args[0]}\".");
+                sb.AppendLine($"[{(int)index}]{ItemTierCatalog.GetItemTierDef(index).name}");
             }
-            else
-            {
-                tierList = (IEnumerable<ItemTier>)StringFinder.Instance.GetItemTiersFromPartial("");
-            }
-            foreach (var tier in tierList)
-            {
-                sb.AppendLine($"[{(int)tier}]{ItemTierCatalog.GetItemTierDef(tier).name}");
-            }
-            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
+            var s = sb.Length > 0 ? sb.ToString().TrimEnd('\n') : string.Format(Lang.NOMATCH_ERROR, "item tiers", arg);
+            Log.MessageNetworked(s, args, LogLevel.MessageClientOnly);
         }
 
         [ConCommand(commandName = "list_item", flags = ConVarFlags.None, helpText = Lang.LISTITEM_HELP)]
         private static void CCListItem(ConCommandArgs args)
         {
             var sb = new StringBuilder();
-            IEnumerable<ItemIndex> itemList;
-            if (args.Count > 0)
+            var arg = args.Count > 0 ? args[0] : "";
+            var indices = StringFinder.Instance.GetItemsFromPartial(arg);
+            foreach (var index in indices)
             {
-                itemList = (IEnumerable<ItemIndex>)StringFinder.Instance.GetItemsFromPartial(args.GetArgString(0));
-                if (itemList.Count() == 0) sb.AppendLine($"No item that matches \"{args[0]}\".");
-            }
-            else
-            {
-                itemList = (IEnumerable<ItemIndex>)ItemCatalog.allItems;
-            }
-            foreach (var itemIndex in itemList)
-            {
-                var definition = ItemCatalog.GetItemDef(itemIndex);
-                bool enabled = false;
+                var definition = ItemCatalog.GetItemDef(index);
                 var realName = Language.currentLanguage.GetLocalizedStringByToken(definition.nameToken);
-                if (Run.instance)
-                {
-                    enabled = Run.instance.IsItemAvailable(itemIndex);
-                }
-                sb.AppendLine($"[{(int)itemIndex}]: {definition.name} \"{realName}\" (enabled={enabled})");
+                bool enabled = Run.instance && Run.instance.IsItemAvailable(index);
+                sb.AppendLine($"[{(int)index}]{definition.name} \"{realName}\" (enabled={enabled})");
             }
-            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
+            var s = sb.Length > 0 ? sb.ToString().TrimEnd('\n') : string.Format(Lang.NOMATCH_ERROR, "items", arg);
+            Log.MessageNetworked(s, args, LogLevel.MessageClientOnly);
         }
 
         [ConCommand(commandName = "list_equip", flags = ConVarFlags.None, helpText = Lang.LISTEQUIP_HELP)]
         private static void CCListEquip(ConCommandArgs args)
         {
             var sb = new StringBuilder();
-            IEnumerable<EquipmentIndex> list;
-            if (args.Count > 0)
+            var arg = args.Count > 0 ? args[0] : "";
+            var indices = StringFinder.Instance.GetEquipsFromPartial(arg);
+            foreach (var index in indices)
             {
-                list = StringFinder.Instance.GetEquipsFromPartial(args[0]);
-                if (list.Count() == 0) sb.AppendLine($"No equipment that matches \"{args[0]}\".");
-            }
-            else
-            {
-                list = EquipmentCatalog.allEquipment;
-            }
-
-            foreach (var equipmentIndex in list)
-            {
-                var definition = EquipmentCatalog.GetEquipmentDef(equipmentIndex);
-                bool enabled = false;
+                var definition = EquipmentCatalog.GetEquipmentDef(index);
                 var realName = Language.currentLanguage.GetLocalizedStringByToken(definition.nameToken);
-                if (Run.instance)
-                {
-                    enabled = Run.instance.IsEquipmentAvailable(equipmentIndex);
-                }
-                sb.AppendLine($"[{(int)equipmentIndex}]: {definition.name} \"{realName}\" (enabled={enabled})");
+                var enabled = Run.instance && Run.instance.IsEquipmentAvailable(index);
+                sb.AppendLine($"[{(int)index}]{definition.name} \"{realName}\" (enabled={enabled})");
             }
-            Log.MessageNetworked(sb.ToString(), args, LogLevel.MessageClientOnly);
+            var s = sb.Length > 0 ? sb.ToString().TrimEnd('\n') : string.Format(Lang.NOMATCH_ERROR, "equipment", arg);
+            Log.MessageNetworked(s, args, LogLevel.MessageClientOnly);
         }
 
         [ConCommand(commandName = "dump_inventories", flags = ConVarFlags.None, helpText = Lang.DUMPINVENTORIES_HELP)]

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -1,11 +1,7 @@
 ﻿using RoR2;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Xml.Linq;
-using UnityEngine;
 using static DebugToolkit.Log;
 
 namespace DebugToolkit.Commands
@@ -20,7 +16,7 @@ namespace DebugToolkit.Commands
             IEnumerable<InteractableSpawnCard> list;
             if (args.Count > 0)
             {
-                list = StringFinder.Instance.GetInteractableSpawnCards(args[0]);
+                list = StringFinder.Instance.GetInteractableSpawnCardsFromPartial(args[0]);
 
                 if (list.Count() == 0)
                     s.AppendLine($"No interactables found that match \"{args[0]}\".");
@@ -307,14 +303,13 @@ namespace DebugToolkit.Commands
                         }
                         else
                         {
-                            string requestedBodyName = StringFinder.Instance.GetBodyName(args[0]);
-                            if (requestedBodyName == null)
+                            var bodyIndex = StringFinder.Instance.GetBodyFromPartial(args[0]);
+                            if (bodyIndex == BodyIndex.None)
                             {
                                 Log.MessageNetworked("Please use list_body to print CharacterBodies", args, LogLevel.MessageClientOnly);
                                 return;
                             }
-                            GameObject newBody = BodyCatalog.FindBodyPrefab(requestedBodyName);
-                            body = newBody.GetComponent<CharacterBody>();
+                            body = BodyCatalog.GetBodyPrefabBodyComponent(bodyIndex);
                         }
                         if (body)
                         {

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -100,13 +100,13 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            string character = StringFinder.Instance.GetBodyName(args[0]);
-            if (character == null)
+            var bodyIndex = StringFinder.Instance.GetBodyFromPartial(args[0]);
+            if (bodyIndex == BodyIndex.None)
             {
                 Log.MessageNetworked(Lang.BODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            GameObject newBody = BodyCatalog.FindBodyPrefab(character);
+            GameObject newBody = BodyCatalog.GetBodyPrefab(bodyIndex);
 
             CharacterMaster master = args.senderMaster;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE)
@@ -121,7 +121,7 @@ namespace DebugToolkit.Commands
             }
 
             master.bodyPrefab = newBody;
-            Log.MessageNetworked(args.sender.userName + " is spawning as " + character, args);
+            Log.MessageNetworked(args.sender.userName + " is spawning as " + newBody.name, args);
 
             if (!master.GetBody())
             {
@@ -220,18 +220,13 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.DUMPSTATS_ARGS, args, LogLevel.ErrorClientOnly);
                 return;
             }
-            var bodyName = StringFinder.Instance.GetBodyName(args[0]);
-            if (bodyName == null)
+            var bodyIndex = StringFinder.Instance.GetBodyFromPartial(args[0]);
+            if (bodyIndex == BodyIndex.None)
             {
                 Log.MessageNetworked(Lang.BODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            var bodyPrefab = BodyCatalog.FindBodyPrefab(bodyName);
-            if (bodyPrefab == null)
-            {
-                Log.MessageNetworked(Lang.BODY_NOTFOUND, args, LogLevel.MessageClientOnly);
-                return;
-            }
+            var bodyPrefab = BodyCatalog.GetBodyPrefab(bodyIndex);
 
             var body = bodyPrefab.GetComponent<CharacterBody>();
             var sb = new System.Text.StringBuilder();
@@ -421,13 +416,12 @@ namespace DebugToolkit.Commands
             }
             else
             {
-                string requestedBodyName = StringFinder.Instance.GetBodyName(args[0]);
-                if (requestedBodyName == null)
+                argBodyIndex = StringFinder.Instance.GetBodyFromPartial(args[0]);
+                if (argBodyIndex == BodyIndex.None)
                 {
                     Log.MessageNetworked(Lang.BODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
                 }
-                argBodyIndex = BodyCatalog.FindBodyIndex(requestedBodyName);
             }
 
             if (!TextSerialization.TryParseInvariant(args[1], out int requestedSkinIndexChange))

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -198,18 +198,15 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked("Can't change a dead player's team. " + Lang.USE_RESPAWN, args, LogLevel.MessageClientOnly);
                 return;
             }
-
-            if (!Enum.TryParse(StringFinder.GetEnumFromPartial<TeamIndex>(args[0]).ToString(), true, out TeamIndex teamIndex))
+            var teamIndex = StringFinder.Instance.GetTeamFromPartial(args[0]);
+            if (teamIndex == StringFinder.TeamIndex_NotFound)
             {
                 Log.MessageNetworked(Lang.TEAM_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            if ((int)teamIndex >= (int)TeamIndex.None && (int)teamIndex < (int)TeamIndex.Count)
-            {
-                master.GetBody().teamComponent.teamIndex = teamIndex;
-                master.teamIndex = teamIndex;
-                Log.MessageNetworked("Changed to team " + teamIndex, args);
-            }
+            master.GetBody().teamComponent.teamIndex = teamIndex;
+            master.teamIndex = teamIndex;
+            Log.MessageNetworked("Changed to team " + teamIndex, args);
         }
 
         [ConCommand(commandName = "dump_stats", flags = ConVarFlags.None, helpText = Lang.DUMPSTATS_HELP)]
@@ -226,9 +223,8 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.BODY_NOTFOUND, args, LogLevel.MessageClientOnly);
                 return;
             }
-            var bodyPrefab = BodyCatalog.GetBodyPrefab(bodyIndex);
+            var body = BodyCatalog.GetBodyPrefabBodyComponent(bodyIndex);
 
-            var body = bodyPrefab.GetComponent<CharacterBody>();
             var sb = new System.Text.StringBuilder();
             sb.AppendLine($"Body: {body.name}");
             sb.AppendLine($"Health: {body.baseMaxHealth} ({FormatLevelStat(body.levelMaxHealth)}/level)");

--- a/Code/DT-Commands/Spawners.cs
+++ b/Code/DT-Commands/Spawners.cs
@@ -111,7 +111,7 @@ namespace DebugToolkit.Commands
             if (args.Count > 2 && args[2] != Lang.DEFAULT_VALUE)
             {
                 var eliteIndex = StringFinder.Instance.GetEliteFromPartial(args[2]);
-                if ((int)eliteIndex == -2)
+                if (eliteIndex == StringFinder.EliteIndex_NotFound)
                 {
                     Log.MessageNetworked(Lang.ELITE_NOTFOUND, args, LogLevel.MessageClientOnly);
                     return;
@@ -127,10 +127,14 @@ namespace DebugToolkit.Commands
             }
 
             TeamIndex teamIndex = TeamIndex.Monster;
-            if (args.Count > 4 && args[4] != Lang.DEFAULT_VALUE && !StringFinder.TryGetEnumFromPartial(args[4], out teamIndex))
+            if (args.Count > 4 && args[4] != Lang.DEFAULT_VALUE)
             {
-                Log.MessageNetworked(Lang.TEAM_NOTFOUND, args, LogLevel.MessageClientOnly);
-                return;
+                teamIndex = StringFinder.Instance.GetTeamFromPartial(args[4]);
+                if (teamIndex == StringFinder.TeamIndex_NotFound)
+                {
+                    Log.MessageNetworked(Lang.TEAM_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    return;
+                }
             }
 
             var spawnCard = StringFinder.Instance.GetDirectorCardFromPartial(masterPrefab.name)?.spawnCard;
@@ -264,7 +268,7 @@ namespace DebugToolkit.Commands
             GameObject body = BodyCatalog.GetBodyPrefab(bodyIndex);
             GameObject gameObject = UnityEngine.Object.Instantiate<GameObject>(body, args.senderBody.transform.position, Quaternion.identity);
             NetworkServer.Spawn(gameObject);
-            Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_1, body), args);
+            Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_1, body.name), args);
         }
 
 

--- a/Code/DT-Commands/Spawners.cs
+++ b/Code/DT-Commands/Spawners.cs
@@ -36,7 +36,7 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked("Can't spawn an object with relation to a dead target.", args, LogLevel.MessageClientOnly);
                 return;
             }
-            var isc = StringFinder.Instance.GetInteractableSpawnCard(args[0]);
+            var isc = StringFinder.Instance.GetInteractableSpawnCardFromPartial(args[0]);
             if (isc == null)
             {
                 Log.MessageNetworked(Lang.INTERACTABLE_NOTFOUND, args, LogLevel.MessageClientOnly);
@@ -92,12 +92,13 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            string character = StringFinder.Instance.GetMasterName(args[0]);
-            if (character == null)
+            var masterIndex = StringFinder.Instance.GetAiFromPartial(args[0]);
+            if (masterIndex == MasterCatalog.MasterIndex.none)
             {
-                Log.MessageNetworked(Lang.SPAWN_ERROR + character, args, LogLevel.MessageClientOnly);
+                Log.MessageNetworked(Lang.SPAWN_ERROR + args[0], args, LogLevel.MessageClientOnly);
                 return;
             }
+            var masterPrefab = MasterCatalog.GetMasterPrefab(masterIndex);
 
             int amount = 1;
             if (args.Count > 1 && args[1] != Lang.DEFAULT_VALUE && !TextSerialization.TryParseInvariant(args[1], out amount))
@@ -132,11 +133,11 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            var spawnCard = StringFinder.Instance.GetDirectorCardFromPartial(character)?.spawnCard;
+            var spawnCard = StringFinder.Instance.GetDirectorCardFromPartial(masterPrefab.name)?.spawnCard;
             if (spawnCard == null)
             {
                 spawnCard = ScriptableObject.CreateInstance<CharacterSpawnCard>();
-                spawnCard.prefab = MasterCatalog.FindMasterPrefab(character);
+                spawnCard.prefab = masterPrefab;
                 spawnCard.sendOverNetwork = true;
                 var body = spawnCard.prefab.GetComponent<CharacterMaster>().bodyPrefab;
                 if (body)
@@ -197,7 +198,7 @@ namespace DebugToolkit.Commands
                 radius *= Mathf.Max(1f, 0.5f * amount);
             }
 
-            Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_2, amount, character), args);
+            Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_2, amount, masterPrefab.name), args);
             for (int i = 0; i < amount; i++)
             {
                 var spawnPosition = position;
@@ -253,17 +254,17 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            string character = StringFinder.Instance.GetBodyName(args[0]);
-            if (character == null)
+            var bodyIndex = StringFinder.Instance.GetBodyFromPartial(args[0]);
+            if (bodyIndex == BodyIndex.None)
             {
                 Log.MessageNetworked(string.Format(Lang.SPAWN_ERROR, args[0]), args, LogLevel.MessageClientOnly);
                 return;
             }
 
-            GameObject body = BodyCatalog.FindBodyPrefab(character);
+            GameObject body = BodyCatalog.GetBodyPrefab(bodyIndex);
             GameObject gameObject = UnityEngine.Object.Instantiate<GameObject>(body, args.senderBody.transform.position, Quaternion.identity);
             NetworkServer.Spawn(gameObject);
-            Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_1, character), args);
+            Log.MessageNetworked(string.Format(Lang.SPAWN_ATTEMPT_1, body), args);
         }
 
 

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -164,6 +164,8 @@
             INVALID_ARG_VALUE = "Invalid value for {0}.",
             INVENTORY_ERROR = "The selected target has no inventory.",
             NEGATIVE_ARG = "Negative value for {0} encountered. It needs to be zero or higher.",
+            NOCONNECTION_ERROR = "Not connected to a server.",
+            NOMATCH_ERROR = "No {0} found that match \"{1}\".",
             NOTINARUN_ERROR = "This command only works when in a Run!",
             NOTINASIMULACRUMRUN_ERROR = "Must be in a Simulacrum Run!",
             NOTINVOIDFIELDS_ERROR = "Must be on Void Fields!",

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -354,7 +354,7 @@ namespace DebugToolkit
         /// <returns>Returns an iterator with all NetworkUsers matched</returns>
         public IEnumerable<NetworkUser> GetPlayersFromPartial(string name)
         {
-            if (int.TryParse(name, out var i))
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
                 if (i >= 0 && i < NetworkUser.readOnlyInstancesList.Count)
                 {
@@ -428,7 +428,7 @@ namespace DebugToolkit
         /// <returns>Returns an iterator with all EliteIndex's matched</returns>
         public IEnumerable<EliteIndex> GetElitesFromPartial(string name)
         {
-            if (int.TryParse(name, out int i))
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
                 var index = (EliteIndex)i;
                 if (index == EliteIndex.None)

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -602,12 +602,16 @@ namespace DebugToolkit
         }
 
         /// <summary>
-        /// Returns a special char stripped language invariant when provided with a BaseNameToke.
+        /// Returns a special char stripped language invariant when provided with a BaseNameToken.
         /// </summary>
         /// <param name="baseToken">The BaseNameToken to query for a Language Invariant.</param>
-        /// <returns>Returns the LanguageInvariant for the BaseNameToken.</returns>
+        /// <returns>Returns the LanguageInvariant for the BaseNameToken, or returns an empty string for a null input.</returns>
         public static string GetLangInvar(string baseToken)
         {
+            if (baseToken == null)
+            {
+                return "";
+            }
             return RemoveSpacesAndAlike(Language.GetString(baseToken));
         }
 

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -1,10 +1,9 @@
-﻿using R2API.Utils;
-using RoR2;
+﻿using RoR2;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
+using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
 
@@ -24,7 +23,12 @@ namespace DebugToolkit
         private static readonly Dictionary<string, string[]> SkinAlias = new Dictionary<string, string[]>();
         private static StringFinder instance;
         private static readonly List<DirectorCard> characterSpawnCard = new List<DirectorCard>();
-        private static List<InteractableSpawnCard> interactableSpawnCards = new List<InteractableSpawnCard>();
+        private static readonly List<InteractableSpawnCard> interactableSpawnCards = new List<InteractableSpawnCard>();
+        private static readonly string NAME_NOTFOUND = "???";
+
+        public static EliteIndex EliteIndex_NotFound = (EliteIndex)(-2);
+        public static ItemTier ItemTier_NotFound = (ItemTier)(-1);
+        public static TeamIndex TeamIndex_NotFound = (TeamIndex)(-2);
 
         public static StringFinder Instance
         {
@@ -144,565 +148,457 @@ namespace DebugToolkit
         }
 
         /// <summary>
-        /// Returns a BuffIndex when provided with a partial/invariant.
+        /// Returns a BuffIndex when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
         /// <returns>Returns the BuffIndex if a match is found, or returns BuffIndex.None</returns>
         public BuffIndex GetBuffFromPartial(string name)
         {
-            foreach (KeyValuePair<string, string[]> dictEnt in BuffAlias)
-            {
-                foreach (string alias in dictEnt.Value)
-                {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                    }
-                }
-            }
-
-            if (Enum.TryParse(name, true, out BuffIndex buffIndex) && BuffCatalog.GetBuffDef(buffIndex) != null)
-            {
-                return buffIndex;
-            }
-
-            foreach (var buff in BuffCatalog.buffDefs)
-            {
-                if (buff.name.ToUpper().Contains(name.ToUpper()))
-                {
-                    return buff.buffIndex;
-                }
-            }
-            return BuffIndex.None;
+            return GetBuffsFromPartial(name).DefaultIfEmpty(BuffIndex.None).First();
         }
 
         /// <summary>
-        /// Returns an array of BuffIndex's when provided with a partial/invariant.
+        /// Returns an iterator of BuffIndex's when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
-        /// <returns>Returns an array with all BuffIndex's matched</returns>
-        public BuffIndex[] GetBuffsFromPartial(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all BuffIndex's matched</returns>
+        public IEnumerable<BuffIndex> GetBuffsFromPartial(string name)
         {
-            var set = new HashSet<BuffIndex>();
-            foreach (KeyValuePair<string, string[]> dictEnt in BuffAlias)
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
-                foreach (string alias in dictEnt.Value)
+                var index = (BuffIndex)i;
+                if (BuffCatalog.GetBuffDef(index) != null)
                 {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                        var buffIndex = BuffCatalog.FindBuffIndex(name);
-                        if (buffIndex != BuffIndex.None)
-                        {
-                            set.Add(buffIndex);
-                        }
-                    }
+                    yield return index;
                 }
+                yield break;
             }
-
+            name = name.ToUpperInvariant();
             foreach (var buff in BuffCatalog.buffDefs)
             {
-                if (buff.name.ToUpper().Contains(name.ToUpper()))
+                if (buff.name.ToUpper().Contains(name))
                 {
-                    set.Add(buff.buffIndex);
+                    yield return buff.buffIndex;
                 }
             }
-            return set.ToArray();
         }
 
         /// <summary>
-        /// Returns a DotIndex when provided with a partial/invariant.
+        /// Returns a DotIndex when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
         /// <returns>Returns the DotIndex if a match is found, or returns DotIndex.None</returns>
         public DotController.DotIndex GetDotFromPartial(string name)
         {
-            foreach (KeyValuePair<string, string[]> dictEnt in DotAlias)
-            {
-                foreach (string alias in dictEnt.Value)
-                {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                    }
-                }
-            }
-
-            if (Enum.TryParse(name, true, out DotController.DotIndex dotIndex) && DotController.GetDotDef(dotIndex) != null)
-            {
-                return dotIndex;
-            }
-
-            foreach (var dot in Enum.GetValues(typeof(DotController.DotIndex)).Cast<DotController.DotIndex>())
-            {
-                if (dot >= DotController.DotIndex.Bleed && dot < DotController.DotIndex.Count)
-                {
-                    var dotName = dot.ToString();
-                    if (dotName.ToUpper().Contains(name.ToUpper()))
-                    {
-                        return dot;
-                    }
-                }
-            }
-            return DotController.DotIndex.None;
+            return GetDotsFromPartial(name).DefaultIfEmpty(DotController.DotIndex.None).First();
         }
 
         /// <summary>
-        /// Returns an array of DotIndex's when provided with a partial/invariant.
+        /// Returns an iterator of DotIndex's when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
-        /// <returns>Returns an array with all the DotIndex's matched</returns>
-        public DotController.DotIndex[] GetDotsFromPartial(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all DotIndex's matched</returns>
+        public IEnumerable<DotController.DotIndex> GetDotsFromPartial(string name)
         {
-            var set = new HashSet<DotController.DotIndex>();
-            foreach (KeyValuePair<string, string[]> dictEnt in DotAlias)
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
-                foreach (string alias in dictEnt.Value)
+                var index = (DotController.DotIndex)i;
+                if (DotController.GetDotDef(index) != null)
                 {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                        if (Enum.TryParse(name, true, out DotController.DotIndex dotIndex) && DotController.GetDotDef(dotIndex) != null)
-                        {
-                            set.Add(dotIndex);
-                        }
-                    }
+                    yield return index;
                 }
+                yield break;
             }
-
+            name = name.ToUpperInvariant();
             foreach (var dot in Enum.GetValues(typeof(DotController.DotIndex)).Cast<DotController.DotIndex>())
             {
                 if (dot >= DotController.DotIndex.Bleed && dot < DotController.DotIndex.Count)
                 {
-                    var dotName = dot.ToString();
-                    if (dotName.ToUpper().Contains(name.ToUpper()))
+                    if (dot.ToString().ToUpper().Contains(name))
                     {
-                        set.Add(dot);
+                        yield return dot;
                     }
                 }
             }
-            return set.ToArray();
         }
 
         /// <summary>
-        /// Returns an EquipmentIndex when provided with a partial/invariant.
+        /// Returns an EquipmentIndex when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
-        /// <returns>Returns the EquiptmentIndex if a match is found, or returns EquiptmentIndex.None</returns>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the EquiptmentIndex if a match is found, or returns EquipmentIndex.None</returns>
         public EquipmentIndex GetEquipFromPartial(string name)
         {
-            string langInvar;
-            foreach (KeyValuePair<string, string[]> dictEnt in EquipAlias)
-            {
-                foreach (string alias in dictEnt.Value)
-                {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                    }
-                }
-            }
-
-            if (Enum.TryParse(name, true, out EquipmentIndex foundEquip) && EquipmentCatalog.IsIndexValid(foundEquip))
-            {
-                return foundEquip;
-            }
-
-            foreach (var equip in typeof(EquipmentCatalog).GetFieldValue<EquipmentDef[]>("equipmentDefs"))
-            {
-                langInvar = GetLangInvar(equip.nameToken.ToUpper());
-                if (equip.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(RemoveSpacesAndAlike(name.ToUpper())))
-                {
-                    return equip.equipmentIndex;
-                }
-            }
-            return EquipmentIndex.None;
+            return GetEquipsFromPartial(name).DefaultIfEmpty(EquipmentIndex.None).First();
         }
 
         /// <summary>
-        /// Returns an array of EquipmentIndex's when provided with a partial/invariant.
+        /// Returns an iterator of EquipmentIndex's when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
-        /// <returns>Returns the EquipmentIndex if a match is found, or returns EquiptmentIndex.None</returns>
-        public EquipmentIndex[] GetEquipsFromPartial(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all EquipmentIndex's matched</returns>
+        public IEnumerable<EquipmentIndex> GetEquipsFromPartial(string name)
         {
-            var set = new HashSet<EquipmentIndex>();
-            string langInvar;
-            foreach (KeyValuePair<string, string[]> dictEnt in EquipAlias)
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
-                foreach (string alias in dictEnt.Value)
+                var index = (EquipmentIndex)i;
+                if (EquipmentCatalog.GetEquipmentDef(index) != null)
                 {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                        if (Enum.TryParse(name, true, out EquipmentIndex foundEquip) && EquipmentCatalog.IsIndexValid(foundEquip))
-                        {
-                            set.Add(foundEquip);
-                        }
-                    }
+                    yield return index;
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var equip in EquipmentCatalog.equipmentDefs)
+            {
+                var langInvar = GetLangInvar(equip.nameToken).ToUpper();
+                if (equip.name.ToUpper().Contains(name) || langInvar.Contains(RemoveSpacesAndAlike(name)))
+                {
+                    yield return equip.equipmentIndex;
                 }
             }
-
-
-            foreach (var equip in typeof(EquipmentCatalog).GetFieldValue<EquipmentDef[]>("equipmentDefs"))
-            {
-                langInvar = GetLangInvar(equip.nameToken.ToUpper());
-                if (equip.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(RemoveSpacesAndAlike(name.ToUpper())))
-                {
-                    set.Add(equip.equipmentIndex);
-                }
-            }
-            //if (set.Count == 0) set.Add(EquipmentIndex.None);
-            return set.ToArray();
         }
 
         /// <summary>
-        /// Returns an ItemTier when provided with a partial/invariant.
+        /// Returns an ItemTierIndex when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Partial Invariant</param>
-        /// <returns>Returns the ItemTier if a match is found, or returns -1</returns>
+        /// <param name="name">Matches either the (int)Index or Partial Invariant</param>
+        /// <returns>Returns the ItemTierIndex if a match is found, or returns -1</returns>
         public ItemTier GetItemTierFromPartial(string name)
         {
-            // Not using Enum.TryParse because we're trying to avoid ItemTier.AssignedAtRuntime
-            if (int.TryParse(name, out int index))
-            {
-                // They are not ordered by tier value!
-                foreach (var tierDef in ItemTierCatalog.allItemTierDefs)
-                {
-                    if ((ItemTier)index == tierDef.tier)
-                    {
-                        return tierDef.tier;
-                    }
-                }
-            }
-
-            foreach (var tierDef in ItemTierCatalog.allItemTierDefs)
-            {
-                if (tierDef.name.ToUpperInvariant().Contains(name.ToUpperInvariant()))
-                {
-                    return tierDef.tier;
-                }
-            }
-            return (ItemTier)(-1);
+            return GetItemTiersFromPartial(name).DefaultIfEmpty(ItemTier_NotFound).First();
         }
 
         /// <summary>
-        /// Returns an array of ItemTier's when provided with a partial/invariant.
+        /// Returns an iterator of ItemTierIndex's when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Partial Invariant</param>
-        /// <returns>Returns the array of ItemTier indices for any matches found</returns>
-        public ItemTier[] GetItemTiersFromPartial(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all ItemTierIndex's matched</returns>
+        public IEnumerable<ItemTier> GetItemTiersFromPartial(string name)
         {
-            var set = new HashSet<ItemTier>();
-            foreach (var tierDef in ItemTierCatalog.allItemTierDefs)
+            var allItemTierDefs = ItemTierCatalog.allItemTierDefs.OrderBy(t => t.tier).ToList();
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
-                if (int.TryParse(name, out int index))
+                var index = (ItemTier)i;
+                foreach (var tierDef in allItemTierDefs)
                 {
-                    if (index == (int)tierDef.tier)
+                    if (tierDef.tier == index)
                     {
-                        set.Add(tierDef.tier);
+                        yield return index;
+                        break;
                     }
                 }
-                else if (tierDef.name.ToUpperInvariant().Contains(name.ToUpperInvariant()))
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var tierDef in allItemTierDefs)
+            {
+                if (tierDef.name.ToUpper().Contains(name))
                 {
-                    set.Add(tierDef.tier);
+                    yield return tierDef.tier;
                 }
             }
-            return set.OrderBy(t => t).ToArray();
         }
 
         /// <summary>
-        /// Returns an ItemIndex when provided with a partial/invariant.
+        /// Returns an ItemIndex when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
         /// <returns>Returns the ItemIndex if a match is found, or returns ItemIndex.None</returns>
         public ItemIndex GetItemFromPartial(string name)
         {
-            string langInvar;
-            foreach (KeyValuePair<string, string[]> dictEnt in ItemAlias)
-            {
-                foreach (string alias in dictEnt.Value)
-                {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-
-                    }
-                }
-            }
-            if (Enum.TryParse(name, true, out ItemIndex foundItem) && ItemCatalog.IsIndexValid(foundItem))
-            {
-                return foundItem;
-            }
-
-            foreach (var item in typeof(ItemCatalog).GetFieldValue<ItemDef[]>("itemDefs"))
-            {
-                langInvar = GetLangInvar(item.nameToken.ToUpper());
-                if (item.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(RemoveSpacesAndAlike(name.ToUpper())))
-                {
-                    return item.itemIndex;
-                }
-            }
-            return ItemIndex.None;
+            return GetItemsFromPartial(name).DefaultIfEmpty(ItemIndex.None).First();
         }
 
         /// <summary>
-        /// Returns an array of ItemIndex's when provided with a partial/invariant.
+        /// Returns an iterator of ItemIndex's when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
-        /// <returns>Returns the ItemIndex if a match is found, or returns ItemIndex.None</returns>
-        public ItemIndex[] GetItemsFromPartial(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all ItemIndex's matched</returns>
+        public IEnumerable<ItemIndex> GetItemsFromPartial(string name)
         {
-            var set = new HashSet<ItemIndex>();
-            string langInvar;
-            foreach (KeyValuePair<string, string[]> dictEnt in ItemAlias)
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
-                foreach (string alias in dictEnt.Value)
+                var index = (ItemIndex)i;
+                if (ItemCatalog.IsIndexValid(index))
                 {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                        if (Enum.TryParse(name, true, out ItemIndex foundItem) && ItemCatalog.IsIndexValid(foundItem))
-                        {
-                            set.Add(foundItem);
-                        }
-                    }
+                    yield return index;
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var item in ItemCatalog.allItemDefs)
+            {
+                var langInvar = GetLangInvar(item.nameToken).ToUpper();
+                if (item.name.ToUpper().Contains(name) || langInvar.Contains(RemoveSpacesAndAlike(name)))
+                {
+                    yield return item.itemIndex;
                 }
             }
-
-            foreach (var item in typeof(ItemCatalog).GetFieldValue<ItemDef[]>("itemDefs"))
-            {
-                langInvar = GetLangInvar(item.nameToken.ToUpper());
-                if (item.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(RemoveSpacesAndAlike(name.ToUpper())))
-                {
-                    set.Add(item.itemIndex);
-                }
-            }
-            //if (set.Count == 0) set.Add(ItemIndex.None);
-            return set.ToArray();
         }
 
         /// <summary>
-        /// Returns an SkinIndex when provided with a partial/invariant.
+        /// Returns a NetworkUser when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact Index, Partial Index, Partial Invariant</param>
-        /// <returns>Returns the SkinIndex if a match is found, or returns SkinIndex.None</returns>
-        public SkinIndex GetSkinFromPartial(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the NetworkUser if a match is found, or returns null</returns>
+        public NetworkUser GetPlayerFromPartial(string name)
         {
-            string langInvar;
-            string nameUpperInvar = name.ToUpperInvariant();
-            foreach (KeyValuePair<string, string[]> dictEnt in SkinAlias)
-            {
-                foreach (string alias in dictEnt.Value)
-                {
-                    if (alias.ToUpperInvariant().Equals(nameUpperInvar))
-                    {
-                        name = dictEnt.Key;
-                    }
-                }
-            }
-            if (Enum.TryParse(name, true, out SkinIndex foundSkin) && foundSkin < (SkinIndex)SkinCatalog.skinCount)
-            {
-                return foundSkin;
-            }
-
-            foreach (var skin in typeof(SkinCatalog).GetFieldValue<SkinDef[]>("allSkinDefs"))
-            {
-                langInvar = GetLangInvar(skin.nameToken.ToUpperInvariant());
-                var langInvarUpper = langInvar.ToUpperInvariant();
-                if (skin.name.ToUpperInvariant().Contains(nameUpperInvar) || langInvarUpper.Contains(nameUpperInvar) || langInvarUpper.Contains(RemoveSpacesAndAlike(nameUpperInvar)))
-                {
-                    return skin.skinIndex;
-                }
-            }
-            return SkinIndex.None;
+            return GetPlayersFromPartial(name).DefaultIfEmpty(null).First();
         }
 
         /// <summary>
-        /// Returns an EliteIndex when provided with a partial/invariant.
+        /// Returns an iterator of NetworkUsers when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Partial Invariant</param>
-        /// <returns>Returns the EliteIndex if a match is found including EliteIndex.None, or returns -2</returns>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all NetworkUsers matched</returns>
+        public IEnumerable<NetworkUser> GetPlayersFromPartial(string name)
+        {
+            if (int.TryParse(name, out var i))
+            {
+                if (i >= 0 && i < NetworkUser.readOnlyInstancesList.Count)
+                {
+                    yield return NetworkUser.readOnlyInstancesList[i];
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var user in NetworkUser.readOnlyInstancesList)
+            {
+                if (user.userName.ToUpper().Contains(name))
+                {
+                    yield return user;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a TeamIndex when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the TeamIndex if a match is found, or returns -2</returns>
+        public TeamIndex GetTeamFromPartial(string name)
+        {
+            return GetTeamsFromPartial(name).DefaultIfEmpty(TeamIndex_NotFound).First();
+        }
+
+        /// <summary>
+        /// Returns an iterator of TeamIndex's when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all TeamIndex's matched</returns>
+        public IEnumerable<TeamIndex> GetTeamsFromPartial(string name)
+        {
+            if (TextSerialization.TryParseInvariant(name, out int i))
+            {
+                var index = (TeamIndex)i;
+                if (index >= TeamIndex.None && index < TeamIndex.Count)
+                {
+                    yield return index;
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var team in Enum.GetValues(typeof(TeamIndex)).Cast<TeamIndex>().OrderBy(t => t))
+            {
+                if (team >= TeamIndex.None && team < TeamIndex.Count)
+                {
+                    if (team.ToString().ToUpper().Contains(name))
+                    {
+                        yield return team;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns an EliteIndex when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the EliteIndex if a match is found, or returns -2</returns>
         public EliteIndex GetEliteFromPartial(string name)
         {
-            if (int.TryParse(name, out int index))
-            {
-                if (index == -1)
-                {
-                    return (EliteIndex)(-1);
-                }
-                else if (EliteCatalog.GetEliteDef((EliteIndex)index) != null)
-                {
-                    return (EliteIndex)index;
-                }
-            }
+            return GetElitesFromPartial(name).DefaultIfEmpty(EliteIndex_NotFound).First();
+        }
 
-            if ("NONE".Contains(name.ToUpperInvariant()))
+        /// <summary>
+        /// Returns an iterator of EliteIndex's when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all EliteIndex's matched</returns>
+        public IEnumerable<EliteIndex> GetElitesFromPartial(string name)
+        {
+            if (int.TryParse(name, out int i))
             {
-                return (EliteIndex)(-1);
+                var index = (EliteIndex)i;
+                if (index == EliteIndex.None)
+                {
+                    yield return index;
+                }
+                else if (EliteCatalog.GetEliteDef(index) != null)
+                {
+                    yield return index;
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            if ("NONE".Contains(name))
+            {
+                yield return EliteIndex.None;
             }
             foreach (var elite in EliteCatalog.eliteDefs)
             {
-                if (elite.name.ToUpperInvariant().Contains(name.ToUpperInvariant()))
+                var langInvar = GetLangInvar(elite.modifierToken).Replace("{0}", "").ToUpper();
+                if (elite.name.ToUpper().Contains(name) || langInvar.Contains(name))
                 {
-                    return elite.eliteIndex;
+                    yield return elite.eliteIndex;
                 }
             }
-            return (EliteIndex)(-2);
-        }
-
-        public DirectorCard GetDirectorCardFromPartial(string masterNameUpper)
-        {
-            var nameUpper = masterNameUpper.ToUpperInvariant();
-
-            foreach (DirectorCard dc in characterSpawnCard)
-            {
-                var spawnCardNameUpper = dc.spawnCard.name.ToUpperInvariant();
-
-                if (nameUpper == spawnCardNameUpper)
-                {
-                    return dc;
-                }
-
-                if (spawnCardNameUpper.Replace("CSC", String.Empty).Equals(nameUpper))
-                {
-                    return dc;
-                }
-            }
-
-            var masterName = GetMasterName(masterNameUpper);
-            if (masterName != null)
-            {
-                masterNameUpper = masterName.ToUpper();
-                foreach (DirectorCard dc in characterSpawnCard)
-                {
-                    var spawnCardPrefabNameUpper = dc.spawnCard.prefab.name.ToUpperInvariant();
-
-                    if (masterNameUpper == spawnCardPrefabNameUpper)
-                    {
-                        return dc;
-                    }
-                }
-            }
-
-            return null;
         }
 
         /// <summary>
-        /// Returns an InteractableSpawnCard given a partial spawncard name
+        /// Returns a DirectorCard when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches a specific spawncard prior to matching a partial.</param>
-        /// <returns>Returns a InteractableSpawncard or throws exception.</returns>
-        public InteractableSpawnCard GetInteractableSpawnCard(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the DirectorCard if a match is found, or returns null</returns>
+        public DirectorCard GetDirectorCardFromPartial(string name)
         {
-            foreach (InteractableSpawnCard isc in interactableSpawnCards)
-            {
-                if (isc.name.ToUpper().Replace("ISC", String.Empty).Equals(name.ToUpper().Replace("ISC", string.Empty)) || isc.name.ToUpper().Replace("ISC", String.Empty).Contains(name.ToUpper()))
-                {
-                    return isc;
-                }
-            }
-
-            return null;
+            return GetDirectorCardsFromPartial(name).DefaultIfEmpty(null).First();
         }
 
         /// <summary>
-        /// Returns an array of InteractableSpawnCards given a partial spawncard name
+        /// Returns an iterator of DirectorCards when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches a specific spawncard prior to matching a partial.</param>
-        /// <returns>Returns a InteractableSpawncard or throws exception.</returns>
-        public InteractableSpawnCard[] GetInteractableSpawnCards(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all DirectorCards matched</returns>
+        public IEnumerable<DirectorCard> GetDirectorCardsFromPartial(string name)
         {
-            HashSet<InteractableSpawnCard> set = new HashSet<InteractableSpawnCard>();
-            foreach (InteractableSpawnCard isc in interactableSpawnCards)
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
-                if (isc.name.ToUpper().Replace("ISC", String.Empty).Equals(name.ToUpper().Replace("ISC", string.Empty)) || isc.name.ToUpper().Replace("ISC", String.Empty).Contains(name.ToUpper()))
+                if (i >= 0 && i < characterSpawnCard.Count)
                 {
-                    set.Add(isc);
+                    yield return characterSpawnCard[i];
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var dc in characterSpawnCard)
+            {
+                if (dc.spawnCard.name.ToUpper().Contains(name))
+                {
+                    yield return dc;
                 }
             }
-
-            return set.ToArray();
         }
 
         /// <summary>
-        /// Returns BodyName when provided with a partial/invariant.
+        /// Returns an InteractableSpawnCard when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact name_BODY, Exact name, Partial name, Partial Invariant</param>
-        /// <returns>Returns the matched body name string or returns null.</returns>
-        public string GetBodyName(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the InteractableSpawnCard if a match is found, or returns null</returns>
+        public InteractableSpawnCard GetInteractableSpawnCardFromPartial(string name)
         {
-            string langInvar;
-            foreach (KeyValuePair<string, string[]> dictEnt in BodyAlias)
+            return GetInteractableSpawnCardsFromPartial(name).DefaultIfEmpty(null).First();
+        }
+
+        /// <summary>
+        /// Returns an iterator of InteractableSpawnCards when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all InteractableSpawnCards matched</returns>
+        public IEnumerable<InteractableSpawnCard> GetInteractableSpawnCardsFromPartial(string name)
+        {
+            if (TextSerialization.TryParseInvariant(name, out int i))
             {
-                foreach (string alias in dictEnt.Value)
+                if (i >= 0 && i < interactableSpawnCards.Count)
                 {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                    }
+                    yield return interactableSpawnCards[i];
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var isc in interactableSpawnCards)
+            {
+                var langInvar = GetLangInvar(GetInteractableName(isc.prefab)).ToUpper();
+                if (isc.name.ToUpper().Contains(name) || langInvar.Contains(name))
+                {
+                    yield return isc;
                 }
             }
-            int i = 0;
+        }
+
+        /// <summary>
+        /// Returns a BodyIndex when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the BodyIndex if a match is found, or returns BodyIndex.None</returns>
+        public BodyIndex GetBodyFromPartial(string name)
+        {
+            return GetBodiesFromPartial(name).DefaultIfEmpty(BodyIndex.None).First();
+        }
+
+        /// <summary>
+        /// Returns an iterator of BodyIndex's when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all BodyIndex's matched</returns>
+        public IEnumerable<BodyIndex> GetBodiesFromPartial(string name)
+        {
+            if (TextSerialization.TryParseInvariant(name, out int i))
+            {
+                var index = (BodyIndex)i;
+                if (BodyCatalog.GetBodyPrefab(index) != null)
+                {
+                    yield return index;
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
             foreach (var body in BodyCatalog.allBodyPrefabBodyBodyComponents)
             {
-                if (int.TryParse(name, out int iName) && i == iName || body.name.ToUpper().Equals(name.ToUpper()) || body.name.ToUpper().Replace("BODY", string.Empty).Equals(name.ToUpper()))
+                var langInvar = GetLangInvar(body.baseNameToken).ToUpper();
+                if (body.name.ToUpper().Contains(name) || langInvar.Contains(RemoveSpacesAndAlike(name)))
                 {
-                    return body.name;
-                }
-                i++;
-            }
-            StringBuilder s = new StringBuilder();
-            foreach (var body in BodyCatalog.allBodyPrefabBodyBodyComponents)
-            {
-                langInvar = GetLangInvar(body.baseNameToken);
-                s.AppendLine(body.name + ":" + langInvar + ":" + name.ToUpper());
-                if (body.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()))
-                {
-                    return body.name;
+                    yield return body.bodyIndex;
                 }
             }
-            return null;
         }
 
         /// <summary>
-        /// Returns MasterName when provided with a partial/invariant.
+        /// Returns a MasterIndex when provided with an index or partial/invariant.
         /// </summary>
-        /// <param name="name">Matches in order: (int)Index, Exact Alias, Exact name_MASTER, Exact name, Partial name, Partial Invariant</param>
-        /// <returns>Returns the matched Master name string or returns null.</returns>
-        public string GetMasterName(string name)
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns the MasterIndex if a match is found, or returns MasterIndex.none</returns>
+        public MasterCatalog.MasterIndex GetAiFromPartial(string name)
         {
-            foreach (KeyValuePair<string, string[]> dictEnt in MasterAlias)
-            {
-                foreach (string alias in dictEnt.Value)
-                {
-                    if (alias.ToUpper().Equals(name.ToUpper()))
-                    {
-                        name = dictEnt.Key;
-                    }
-                }
-            }
-            int i = 0;
-            foreach (var master in MasterCatalog.allAiMasters)
-            {
-                if (int.TryParse(name, out int iName) && i == iName || master.name.ToUpper().Equals(name.ToUpper()) || master.name.ToUpper().Replace("MASTER", string.Empty).Equals(name.ToUpper()))
-                {
-                    return master.name;
-                }
-                i++;
-            }
-            StringBuilder s = new StringBuilder();
-            foreach (var master in MasterCatalog.allAiMasters)
-            {
+            return GetAisFromPartial(name).DefaultIfEmpty(MasterCatalog.MasterIndex.none).First();
+        }
 
-                var langInvar = GetLangInvar(master.bodyPrefab.GetComponent<CharacterBody>().baseNameToken);
-                s.AppendLine(master.name + ":" + langInvar + ":" + name.ToUpper());
-                if (master.name.ToUpper().Contains(name.ToUpper()) || langInvar.ToUpper().Contains(name.ToUpper()))
+        /// <summary>
+        /// Returns an iterator of MasterIndex's when provided with an index or partial/invariant.
+        /// </summary>
+        /// <param name="name">Matches either the exact (int)Index or Partial Invariant</param>
+        /// <returns>Returns an iterator with all MasterIndex's matched</returns>
+        public IEnumerable<MasterCatalog.MasterIndex> GetAisFromPartial(string name)
+        {
+            if (TextSerialization.TryParseInvariant(name, out int i))
+            {
+                var index = (MasterCatalog.MasterIndex)i;
+                if (MasterCatalog.GetMasterPrefab(index) != null)
                 {
-                    return master.name;
+                    yield return index;
+                }
+                yield break;
+            }
+            name = name.ToUpperInvariant();
+            foreach (var ai in MasterCatalog.allAiMasters)
+            {
+                var langInvar = GetLangInvar(GetMasterName(ai)).ToUpper();
+                if (ai.name.ToUpper().Contains(name) || langInvar.Contains(name))
+                {
+                    yield return ai.masterIndex;
                 }
             }
-            return null;
         }
 
         /// <summary>
@@ -718,6 +614,43 @@ namespace DebugToolkit
         public static string RemoveSpacesAndAlike(string input)
         {
             return Regex.Replace(input, @"[ '-]", string.Empty);
+        }
+
+        public static string GetInteractableName(GameObject prefab)
+        {
+            if (prefab == null)
+            {
+                return NAME_NOTFOUND;
+            }
+            var display = prefab.GetComponent<IDisplayNameProvider>();
+            if (display != null)
+            {
+                return display.GetDisplayName();
+            }
+            var multishop = prefab.GetComponent<MultiShopController>();
+            if (multishop != null && multishop.terminalPrefab)
+            {
+                display = multishop.terminalPrefab.GetComponent<IDisplayNameProvider>();
+                if (display != null)
+                {
+                    return display.GetDisplayName();
+                }
+            }
+            return NAME_NOTFOUND;
+        }
+
+        public static string GetMasterName(CharacterMaster master)
+        {
+            if (master == null)
+            {
+                return NAME_NOTFOUND;
+            }
+            var body = master?.bodyPrefab.GetComponent<CharacterBody>();
+            if (body != null)
+            {
+                return body.GetDisplayName();
+            }
+            return NAME_NOTFOUND;
         }
 
         /// <summary>

--- a/Code/Util.cs
+++ b/Code/Util.cs
@@ -9,40 +9,13 @@ namespace DebugToolkit
         /// Returns a matched NetworkUser when provided to a player.
         /// </summary>
         /// <param name="args">(string[])args array</param>
-        /// <param name="startLocation">(int)on the string array, at which index the player string starts at. Default value is 0</param>
+        /// <param name="startLocation">(int)on the string array, at which index the player string is. Default value is 0</param>
         /// <returns>Returns a NetworkUser if a match is found, or null if not</returns>
-        internal static NetworkUser GetNetUserFromString(List<string> args, int startLocation = 0)
+        internal static NetworkUser GetNetUserFromString(List<string> args, int index = 0)
         {
-            if (args.Count > 0 && startLocation < args.Count)
+            if (args.Count > 0 && index < args.Count)
             {
-                // This doesn't seem to be necessary
-                if (args[startLocation].StartsWith("\""))
-                {
-                    var startString = string.Join(" ", args);
-
-                    var startIndex = startString.IndexOf('\"') + 1;
-                    var length = startString.LastIndexOf('\"') - startIndex;
-
-                    args[startLocation] = startString.Substring(startIndex, length);
-                }
-
-                if (int.TryParse(args[startLocation], out int result))
-                {
-                    if (result < NetworkUser.readOnlyInstancesList.Count && result >= 0)
-                    {
-                        return NetworkUser.readOnlyInstancesList[result];
-                    }
-                    return null;
-                }
-
-                foreach (var n in NetworkUser.readOnlyInstancesList)
-                {
-                    if (n.userName.ToLower().Contains(args[startLocation].ToLower()))
-                    {
-                        return n;
-                    }
-                }
-                return null;
+                return StringFinder.Instance.GetPlayerFromPartial(args[index]);
             }
             return null;
         }
@@ -56,16 +29,15 @@ namespace DebugToolkit
         /// <returns>Returns the found master. Null otherwise</returns>
         internal static CharacterMaster GetTargetFromArgs(List<string> args, int index, bool isDedicatedServer)
         {
-            CharacterMaster target;
-            if (!isDedicatedServer && args[index].ToUpperInvariant() == Lang.PINGED)
+            if (args.Count > 0 && index < args.Count)
             {
-                target = Hooks.GetPingedMaster();
+                if (!isDedicatedServer && args[index].ToUpperInvariant() == Lang.PINGED)
+                {
+                    return Hooks.GetPingedMaster();
+                }
+                return GetNetUserFromString(args, index)?.master;
             }
-            else
-            {
-                target = GetNetUserFromString(args, index)?.master;
-            }
-            return target;
+            return null;
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Commands:
 
 List Commands:
 
-* [All the `list_` commands support filtering](https://user-images.githubusercontent.com/72328339/213889205-2dbaab4f-3b88-481e-ba29-2a466a10ed53.png)
+* [All the `list_` commands support filtering](https://user-images.githubusercontent.com/57867641/295963274-169b2fd9-a5ea-41df-8dba-2632f75ddbd4.png). A number for the unique index or any string for partial matching.
 * **list_player** - List all Players and their ID.
 * **list_body** - List all Bodies and their language invariants.
 * **list_ai** - List all Masters and their language invariants.


### PR DESCRIPTION
Closes #162. Not sure if this also applies to #61.

Every partial matching method now returns the unique element at some index if the argument can be parsed as an integer, otherwise it tries to match the partial for all available entries. The entries are returned in the order they are encountered in one iteration, without prioritising exact name matches. This also means the list commands can now reuse these methods.

Changes made for highlighting uniformity:
- No partial/list method matches a number as either a partial index or partial name. `list_player` used to be the exception in only matching the index in such a scenario but is now the standard.
- Fixed the interactable/director card methods not matching for an index, or for not showing the indices for the respective list commands.
- Fixed the elites, director and interactable cards missing lang invariants.

Other small changes made along the way:
- Changed `GetBodyName` and `GetMasterName` to return Body/MasterIndex to conform to every other method. Besides, returning the name still required fetching the prefab from the relevant catalog and in some cases it is the EnumIndex itself that was sought after.
- The spawn card methods used to replace "isc" and "csc" anywhere in the name. This allowed bugs for strings like "disc" and "AdjectiveEndingInCScav". Even if the replacement were to be made only at the beginning, showing truncated names would mean someone using "ed" for elites would expect to get it matched only for "haunted", but it would silently end up as an empty string and match everything. Therefore, neither the matching methods nor the list commands now remove any prefixes. This also applies for buffs, elites, and anything else with a prefix/affix.
- `kill_all` was slightly modified to only iterate the members of the targetted team instead of all masters.
- `Util.GetNetUserFromString` has been minimised to effectively call `GetPlayerFromPartial`. The old bit about stitching together arguments is unnecessary. The inputs, for example, `irrelevant "target name"` are already parsed as `[irrelevant, target name]`. In fact, the logic has a bug where the inputs `irrelevant '"target name' '...NOT"'` would eventually be stitched into `[irrelevant, "target name...NOT"]`. The rest of the method's code was just reinventing the wheel.
	- As a sidenote, I also added the boundary check from this method to `Util.GetTargetFromArgs`.
- Removed `GetSkinFromPartial` because it isn't used by anything. `list_skins` and `loadout_set_skin_variant` don't require matching any partial.

![list_query_examples](https://github.com/harbingerofme/DebugToolkit/assets/57867641/169b2fd9-a5ea-41df-8dba-2632f75ddbd4)

Matching order
--
I've implemented the simple approach which matches anything in the order it is encountered in the iterable. mostly to imitate how the list commands behaved. However, this means that since "WispMaster" comes after "AncientWispMaster", there is no way to match the latter other than with the index. I'm mentioning it since spawning a wisp might be frequent in testing and using the index could be inconvenient. So maybe switching to the alternative approach mentioned in #162 might make more sense.

Pending issue
--
I don't know what to do with the alias dictionaries in StringFinder. Since they have not been exposed to the user via the list commands, only those who have read the code may know of their existence. It may make sense to either remove them completely, or show them alongside the invariants in the list commands and similarly allow them to be matched, e.g., `[i]Fracture (Collapse)`, `[i]RoboBallBossMaster="Solus Control Unit" (SCU, roboboss)`. If they are to be kept, I think it makes sense to match them just like the partial/invariant. However, most of the current aliases are redundant either because they are partials of their referenced name, or the object itself now has a friendly name. The only ones still using internal names are buffs and dots, which are also referenced similarly in the wiki. I can see the use for it for "Alloy Worship Unit" -> "AWU", but it seems such cases are few and far between.