### PR TITLE
Support enum for autocompletion more naturally and add any missing attributes from commands

### DIFF
--- a/Code/AutoCompletion.cs
+++ b/Code/AutoCompletion.cs
@@ -19,16 +19,19 @@ namespace DebugToolkit
         public AutoCompletionAttribute(Type classType, string catalogName, string nestedField = "", bool dynamic = false)
         {
             ClassType = classType;
-            if (catalogName != null)
-            {
-                Catalog = classType.GetFieldValue<IEnumerable<object>>(catalogName);
-            }
-            else
-            {
-                IsEnum = true;
-            }
+            Catalog = classType.GetFieldValue<IEnumerable<object>>(catalogName);
             NestedField = nestedField;
             Dynamic = dynamic;
+        }
+
+        public AutoCompletionAttribute(Type enumType)
+        {
+            if (!enumType.IsEnum)
+            {
+                throw new ArgumentException("Argument is not an enum");
+            }
+            ClassType = enumType;
+            IsEnum = true;
         }
     }
 
@@ -86,7 +89,7 @@ namespace DebugToolkit
                         foreach (var field in attribute.ClassType.GetFields())
                         {
                             var fieldName = field.Name;
-                            if (fieldName != "value__" && fieldName != "None" && fieldName != "Count")
+                            if (fieldName != "value__" && fieldName != "Count")
                             {
                                 toFill.Add(commandName + fieldName);
                             }

--- a/Code/DT-Commands/Buffs.cs
+++ b/Code/DT-Commands/Buffs.cs
@@ -341,7 +341,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "give_dot", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.GIVEDOT_HELP)]
-        [AutoCompletion(typeof(DotController.DotIndex), null)]
+        [AutoCompletion(typeof(DotController.DotIndex))]
         private static void CCGiveDot(ConCommandArgs args)
         {
             if (!Run.instance)

--- a/Code/DT-Commands/Buffs.cs
+++ b/Code/DT-Commands/Buffs.cs
@@ -423,6 +423,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "remove_dot", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.REMOVEDOT_HELP)]
+        [AutoCompletion(typeof(DotController.DotIndex))]
         private static void CCRemoveDot(ConCommandArgs args)
         {
             if (!Run.instance)
@@ -481,6 +482,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "remove_dot_stacks", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.REMOVEDOTSTACKS_HELP)]
+        [AutoCompletion(typeof(DotController.DotIndex))]
         private static void CCRemoveDotStacks(ConCommandArgs args)
         {
             if (!Run.instance)

--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -182,6 +182,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "kill_all", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.KILLALL_HELP)]
+        [AutoCompletion(typeof(TeamIndex))]
         private static void CCKillAll(ConCommandArgs args)
         {
             if (!Run.instance)

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -419,6 +419,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "create_potential", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.CREATEPOTENTIAL_HELP)]
+        [AutoCompletion(typeof(ItemTierCatalog), "itemTierDefs")]
         private static void CCCreatePotential(ConCommandArgs args)
         {
             if (!Run.instance)
@@ -487,6 +488,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "remove_item_stacks", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.REMOVEITEMSTACKS_HELP)]
+        [AutoCompletion(typeof(ItemCatalog), "itemDefs", "nameToken")]
         private static void CCRemoveItemStacks(ConCommandArgs args)
         {
             if (!Run.instance)

--- a/Code/DT-Commands/LobbyManagement.cs
+++ b/Code/DT-Commands/LobbyManagement.cs
@@ -19,47 +19,9 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.KICK_ARGS, args, LogLevel.Error);
                 return;
             }
-            NetworkUser nu = Util.GetNetUserFromString(args.userArgs);
-            if (nu == null)
-            {
-                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.Error);
-                return;
-            }
-
-            // Check if we can kick targeted user.
-            if (!Application.isBatchMode)
-            {
-                foreach (var serverLocalUsers in NetworkUser.readOnlyLocalPlayersList)
-                {
-                    if (serverLocalUsers == nu)
-                    {
-                        Log.MessageNetworked("Specified user is hosting.", args, LogLevel.Error);
-                        return;
-                    }
-                }
-            }
-            else if (PermissionSystem.IsEnabled.Value)
-            {
-                if (!PermissionSystem.HasMorePerm(args.sender, nu, args))
-                {
-                    Log.MessageNetworked("The target has a higher permission level that you.", args, LogLevel.Error);
-                    return;
-                }
-            }
-
-            NetworkConnection client = null;
-            foreach (var connection in NetworkServer.connections)
-            {
-                if (nu.connectionToClient == connection)
-                {
-                    client = connection;
-                    break;
-                }
-            }
-
+            var client = GetClientFromArgs(args);
             if (client == null)
             {
-                Log.MessageNetworked("Error trying to find the associated connection with the user", args, LogLevel.Error);
                 return;
             }
             var reason = new NetworkManagerSystem.SimpleLocalizedKickReason("KICK_REASON_KICK");
@@ -73,50 +35,12 @@ namespace DebugToolkit.Commands
         {
             if (args.Count == 0)
             {
-                Log.MessageNetworked(Lang.BAN_ARGS, args, LogLevel.Error);
+                Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.BAN_ARGS, args, LogLevel.Error);
                 return;
             }
-            NetworkUser nu = Util.GetNetUserFromString(args.userArgs);
-            if (nu == null)
+            var client = GetClientFromArgs(args);
+            if (client == null)
             {
-                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.Error);
-                return;
-            }
-
-            // Check if we can kick targeted user.
-            if (!Application.isBatchMode)
-            {
-                foreach (var serverLocalUsers in NetworkUser.readOnlyLocalPlayersList)
-                {
-                    if (serverLocalUsers == nu)
-                    {
-                        Log.MessageNetworked("Specified user is hosting.", args, LogLevel.Error);
-                        return;
-                    }
-                }
-            }
-            else if (PermissionSystem.IsEnabled.Value)
-            {
-                if (!PermissionSystem.HasMorePerm(args.sender, nu, args))
-                {
-                    Log.MessageNetworked("The target has a higher permission level that you.", args, LogLevel.Error);
-                    return;
-                }
-            }
-
-            NetworkConnection client = null;
-            foreach (var connection in NetworkServer.connections)
-            {
-                if (nu.connectionToClient == connection)
-                {
-                    client = connection;
-                    break;
-                }
-            }
-
-            if (client != null)
-            {
-                Log.MessageNetworked("Error trying to find the associated connection with the user", args, LogLevel.Error);
                 return;
             }
             NetworkManagerSystem.singleton.ServerBanClient(client);
@@ -145,6 +69,55 @@ namespace DebugToolkit.Commands
 
             master.TrueKill();
             Log.MessageNetworked(master.name + " was killed by server.", args);
+        }
+
+        private static NetworkConnection GetClientFromArgs(ConCommandArgs args)
+        {
+            NetworkUser nu = Util.GetNetUserFromString(args.userArgs);
+            if (nu == null)
+            {
+                Log.MessageNetworked(Lang.PLAYER_NOTFOUND, args, LogLevel.Error);
+                return null;
+            }
+
+            // Check if we can kick targeted user.
+            if (!Application.isBatchMode)
+            {
+                foreach (var serverLocalUsers in NetworkUser.readOnlyLocalPlayersList)
+                {
+                    if (serverLocalUsers == nu)
+                    {
+                        Log.MessageNetworked("Specified user is hosting.", args, LogLevel.Error);
+                        return null;
+                    }
+                }
+            }
+            else if (PermissionSystem.IsEnabled.Value)
+            {
+                if (!PermissionSystem.HasMorePerm(args.sender, nu, args))
+                {
+                    Log.MessageNetworked("The target has a higher permission level that you.", args, LogLevel.Error);
+                    return null;
+                }
+            }
+
+            NetworkConnection client = null;
+            foreach (var connection in NetworkServer.connections)
+            {
+                if (nu.connectionToClient == connection)
+                {
+                    client = connection;
+                    break;
+                }
+            }
+
+            if (client == null)
+            {
+                Log.MessageNetworked("Error trying to find the associated connection with the user", args, LogLevel.Error);
+                return null;
+            }
+
+            return client;
         }
     }
 }

--- a/Code/DT-Commands/LobbyManagement.cs
+++ b/Code/DT-Commands/LobbyManagement.cs
@@ -10,6 +10,7 @@ namespace DebugToolkit.Commands
     class LobbyManagement
     {
         [ConCommand(commandName = "kick", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.KICK_HELP)]
+        [AutoCompletion(typeof(NetworkUser), "instancesList", "userName", true)]
         [RequiredLevel]
         private static void CCKick(ConCommandArgs args)
         {
@@ -66,6 +67,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "ban", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.BAN_HELP)]
+        [AutoCompletion(typeof(NetworkUser), "instancesList", "userName", true)]
         [RequiredLevel]
         private static void CCBan(ConCommandArgs args)
         {
@@ -121,6 +123,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "true_kill", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.TRUEKILL_HELP)]
+        [AutoCompletion(typeof(NetworkUser), "instancesList", "userName", true)]
         private static void CCTrueKill(ConCommandArgs args)
         {
             if (args.sender == null && args.Count < 1)

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -169,6 +169,7 @@ namespace DebugToolkit.Commands
         }
 
         [ConCommand(commandName = "change_team", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.CHANGETEAM_HELP)]
+        [AutoCompletion(typeof(TeamIndex))]
         private static void CCChangeTeam(ConCommandArgs args)
         {
             if (!Run.instance)


### PR DESCRIPTION
Constructor overload better than passing a null to affect its behaviour. Also a fair few commands missing autocompletion, most of which had to do with enums.

I also refactored the client parsing for the kick/ban commands since I had a look at the file and it stood out. For sake of sanity I have to confirm that at the end of the refactored method it's supposed to check for `client == null`, right? Because before `ban` checked for not null. I think it's an error unless I'm missing something.