### PR TITLE
Make god toggle more consistent

### DIFF
--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -16,16 +16,13 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
-            bool hasNotYetRun = true;
+            var modeOn = Hooks.ToggleGod();
             foreach (var playerInstance in PlayerCharacterMasterController.instances)
             {
-                playerInstance.master.ToggleGod();
-                if (hasNotYetRun)
-                {
-                    Log.MessageNetworked($"God mode {(playerInstance.master.godMode ? "enabled" : "disabled")}.", args);
-                    hasNotYetRun = false;
-                }
+                playerInstance.master.godMode = modeOn;
+                playerInstance.master.UpdateBodyGodMode();
             }
+            Log.MessageNetworked($"God mode {(modeOn ? "enabled" : "disabled")}.", args);
         }
 
         [ConCommand(commandName = "buddha", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.BUDDHA_HELP)]

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -11,11 +11,6 @@ namespace DebugToolkit.Commands
         [ConCommand(commandName = "god", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.GOD_HELP)]
         private static void CCGodModeToggle(ConCommandArgs args)
         {
-            if (!Run.instance)
-            {
-                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
-                return;
-            }
             var modeOn = Hooks.ToggleGod();
             foreach (var playerInstance in PlayerCharacterMasterController.instances)
             {
@@ -31,11 +26,6 @@ namespace DebugToolkit.Commands
         [ConCommand(commandName = "budda", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.BUDDHA_HELP)]
         private static void CCBuddhaModeToggle(ConCommandArgs args)
         {
-            if (!Run.instance)
-            {
-                Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
-                return;
-            }
             bool modeOn = Hooks.ToggleBuddha();
             Log.MessageNetworked($"Buddha mode {(modeOn ? "enabled" : "disabled")}.", args);
         }

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using UnityEngine.Networking;
 using Console = RoR2.Console;
 
 namespace DebugToolkit
@@ -24,6 +25,7 @@ namespace DebugToolkit
         private static CharacterBody pingedBody;
         private static CharacterMaster pingedMaster;
         private static bool buddha;
+        private static bool god;
 
         public static void InitializeHooks()
         {
@@ -57,6 +59,16 @@ namespace DebugToolkit
 
             //Buddha Mode hook
             On.RoR2.HealthComponent.TakeDamage += NonLethatDamage;
+            On.RoR2.CharacterMaster.Awake += SetGodMode;
+        }
+
+        private static void SetGodMode(On.RoR2.CharacterMaster.orig_Awake orig, CharacterMaster self)
+        {
+            orig(self);
+            if (NetworkServer.active)
+            {
+                self.godMode |= self.playerCharacterMasterController && god;
+            }
         }
 
         private static void NonLethatDamage(On.RoR2.HealthComponent.orig_TakeDamage orig,HealthComponent self,DamageInfo damageInfo){
@@ -484,8 +496,14 @@ namespace DebugToolkit
             return pingedMaster;
         }
 
-        internal static bool ToggleBuddha(){
-            return (buddha = !buddha);
+        internal static bool ToggleBuddha()
+        {
+            return buddha = !buddha;
+        }
+
+        internal static bool ToggleGod()
+        {
+            return god = !god;
         }
     }
 }


### PR DESCRIPTION
If a player joins with the drop-in multiplayer mod, or somehow the server modifies the god value of any character manually, calling `god` toggles the individual value for everyone. It's better to store the god state internally, like `buddha` does, and use that for everyone.

Now the command works similar to both `buddha` and `no_enemies`, which persist between runs. And like the latter, there is no reason to have the value toggleable only within a run.