### PR TITLE
Change portal commands (change add_portal, add spawn_portal)

### DIFF
--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -35,48 +35,36 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.INSUFFICIENT_ARGS + Lang.ADDPORTAL_ARGS, args, LogLevel.MessageClientOnly);
                 return;
             }
-            var portalName = args[0].ToLower();
             var teleporterInteraction = TeleporterInteraction.instance;
             if (!teleporterInteraction)
             {
-                if (portalName != "arena" && portalName != "null" && portalName != "void")
-                {
-                    Log.MessageNetworked("No teleporter interaction instance! Can only spawn null portal", args, LogLevel.WarningClientOnly);
-                    return;
-                }
+                Log.MessageNetworked("No teleporter interaction instance!", args, LogLevel.WarningClientOnly);
+                return;
             }
 
+            var portalName = args[0].ToUpperInvariant();
             switch (portalName)
             {
-                case "blue":
+                case "BLUE":
                     teleporterInteraction.shouldAttemptToSpawnShopPortal = true;
                     break;
-                case "gold":
+                case "GOLD":
                     teleporterInteraction.shouldAttemptToSpawnGoldshoresPortal = true;
                     break;
-                case "celestial":
+                case "CELESTIAL":
                     teleporterInteraction.shouldAttemptToSpawnMSPortal = true;
                     break;
-                case "deepvoid":
-                    QueueDeepVoidPortal();
-                    break;
-                case "void":
+                case "VOID":
                     QueueVoidPortal();
                     break;
-                case "arena":
-                case "null":
-                    SpawnArenaPortal();
-                    break;
-                case "all":
-                    teleporterInteraction.shouldAttemptToSpawnGoldshoresPortal = true;
+                case Lang.ALL:
                     teleporterInteraction.shouldAttemptToSpawnShopPortal = true;
                     teleporterInteraction.shouldAttemptToSpawnMSPortal = true;
-                    SpawnArenaPortal();
-                    QueueDeepVoidPortal();
+                    teleporterInteraction.shouldAttemptToSpawnGoldshoresPortal = true;
                     QueueVoidPortal();
                     break;
                 default:
-                    Log.MessageNetworked(Lang.PORTAL_NOTFOUND, args, LogLevel.MessageClientOnly);
+                    Log.MessageNetworked(string.Format(Lang.INVALID_ARG_VALUE, "portal"), args, LogLevel.MessageClientOnly);
                     return;
             }
 
@@ -106,43 +94,6 @@ namespace DebugToolkit.Commands
                         // Does it even matter if I cache them?
                         array[i].spawnChance = cachedSpawnChance;
                         array[i].minStagesCleared = cachedMinStagesCleared;
-                        break;
-                    }
-                }
-            }
-
-            //Can't be queued, unless an arena portal spawn card is made
-            void SpawnArenaPortal()
-            {
-                var arenaPortal = UnityEngine.Object.Instantiate(LegacyResourcesAPI.Load<GameObject>("Prefabs/NetworkedObjects/PortalArena"), args.senderBody.corePosition, Quaternion.identity);
-                arenaPortal.GetComponent<SceneExitController>().useRunNextStageScene = false;
-                NetworkServer.Spawn(arenaPortal);
-            }
-
-            void QueueDeepVoidPortal()
-            {
-                PortalSpawner[] array = teleporterInteraction.portalSpawners;
-                for (int i = 0; i < array.Length; i++)
-                {
-                    if (array[i].portalSpawnCard != LegacyResourcesAPI.Load<InteractableSpawnCard>("SpawnCards/InteractableSpawnCard/iscDeepVoidPortal"))
-                    {
-                        var list = teleporterInteraction.portalSpawners.ToList();
-
-                        var deepVoidPortalSpawner = teleporterInteraction.gameObject.AddComponent<PortalSpawner>();
-                        deepVoidPortalSpawner.maxSpawnDistance = teleporterInteraction.portalSpawners[0].maxSpawnDistance;
-                        deepVoidPortalSpawner.minSpawnDistance = teleporterInteraction.portalSpawners[0].minSpawnDistance;
-                        deepVoidPortalSpawner.minStagesCleared = 0;
-                        deepVoidPortalSpawner.portalSpawnCard = LegacyResourcesAPI.Load<InteractableSpawnCard>("SpawnCards/InteractableSpawnCard/iscDeepVoidPortal");
-                        deepVoidPortalSpawner.previewChild = null;
-                        deepVoidPortalSpawner.previewChildName = null;
-                        deepVoidPortalSpawner.requiredExpansion = teleporterInteraction.portalSpawners[0].requiredExpansion;
-                        deepVoidPortalSpawner.rng = teleporterInteraction.portalSpawners[0].rng;
-                        deepVoidPortalSpawner.spawnChance = 1;
-                        deepVoidPortalSpawner.spawnMessageToken = "PORTAL_DEEPVOID_OPEN";
-                        deepVoidPortalSpawner.spawnPreviewMessageToken = "PORTAL_DEEPVOID_WILL_OPEN";
-                        list.Add(deepVoidPortalSpawner);
-
-                        teleporterInteraction.portalSpawners = list.ToArray();
                         break;
                     }
                 }

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -40,6 +40,7 @@ namespace DebugToolkit
             On.RoR2.Console.AutoComplete.ctor += CommandArgsAutoCompletion;
             RoR2Application.onLoad += ArgsAutoCompletion.GatherCommandsAndFillStaticArgs;
             RoR2Application.onLoad += Items.InitDroptableData;
+            RoR2Application.onLoad += Spawners.InitPortals;
             Run.onRunStartGlobal += Items.CollectItemTiers;
             IL.RoR2.UI.ConsoleWindow.Update += SmoothDropDownSuggestionNavigation;
             IL.RoR2.Networking.NetworkManagerSystem.CCSetScene += EnableCheatsInCCSetScene;

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -53,6 +53,7 @@
             SPAWNAS_ARGS = "Requires 1 argument: {body} [player:<self>]",
             SPAWNBODY_ARGS = "Requires 1 argument: {body}",
             SPAWNINTERACTABLE_ARGS = "Requires 1 argument: {interactable}",
+            SPAWNPORTAL_ARGS = "Requires 1 argument: {portal ('artifact'|'blue'|'celestial'|'deepvoid'|'gold'|'null'|'void')}",
             TIMESCALE_ARGS = "Requires 1 argument: {time_scale}",
             TRUEKILL_ARGS = "Requires 0 (1 if from server) arguments: [player:<self>]"
             ;
@@ -130,6 +131,7 @@
             SPAWNAI_HELP = "Spawns the specified CharacterMaster. " + SPAWNAI_ARGS,
             SPAWNBODY_HELP = "Spawns the specified dummy body. " + SPAWNBODY_ARGS,
             SPAWNINTERACTABLE_HELP = "Spawns the specified interactable. List_Interactable for options. " + SPAWNINTERACTABLE_ARGS,
+            SPAWNPORTAL_HELP = "Spawns a portal in front of the player. " + SPAWNPORTAL_ARGS,
             TIMESCALE_HELP = "Sets the Time Delta. " + TIMESCALE_ARGS,
             TRUEKILL_HELP = "Ignore Dio's and kill the entity. " + TRUEKILL_ARGS
             ;

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -6,7 +6,7 @@
 
         // Command arguments
         public const string
-            ADDPORTAL_ARGS = "Requires 1 argument: {portal ('blue'|'gold'|'celestial'|'null'|'void'|'deepvoid'|'all')}",
+            ADDPORTAL_ARGS = "Requires 1 argument: {portal ('blue'|'celestial'|'gold'|'void'|'all')}",
             BAN_ARGS = "Requires 1 argument: {player}",
             BIND_ARGS = "Requires 2 arguments: {key} {console_commands}",
             BIND_DELETE_ARGS = "Requires 1 argument: {key}",
@@ -177,7 +177,6 @@
             PARSE_ERROR = "Unable to parse {0} to {1}.",
             PINGEDBODY_NOTFOUND = "Pinged target not found. Either the last ping was not a character, or it has been destroyed since.",
             PLAYER_NOTFOUND = "Specified player not found or isn't alive. Please use list_player for options.",
-            PORTAL_NOTFOUND = "The specified portal could not be found. Valid portals: 'blue','gold','celestial','null','void','deepvoid','all'",
             SPAWN_ERROR = "Could not spawn: ",
             STAGE_NOTFOUND = "Stage not found. Please use scene_list for options.",
             TEAM_NOTFOUND = "Team type not found. Please use list_team for options."

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Commands:
 * **next_wave** - Advance to the next Simulacrum wave. `next_wave`
 * **force_wave** - Set the next wave prefab. `force_wave [wave_prefab]`. If no input is supplied, prints all available options and clears any previous selection.
 * **run_set_waves_cleared** - Set the Simulacrum waves cleared. Must be positive. `set_run_waves_cleared {wave}`
-* **add_portal** - Teleporter will attempt to spawn after the teleporter completion. `add_portal {portal ('blue'|'gold'|'celestial'|'null'|'void'|'deepvoid'|'all')}`. The `null` portal doesn't require a teleporter and will spawn in front of the player.
+* **add_portal** - Add a portal to the current Teleporter on completion. `add_portal {portal ('blue'|'celestial'|'gold'|'void'|'all')}`.
 * **seed** - Set the seed for all next runs this session. `seed [new_seed]`. Use `0` to specify the game should generate its own seed. If used without argument, it's equivalent to the vanilla `run_get_seed`.
 * **kill_all** - Kills all members of a specified team. `kill_all [team:Monster]`.
 * **true_kill** - Truly kill a player, ignoring revival effects. `true_kill *[player:<self>]`

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Item Commands:
 Spawn Commands:
 
 * **spawn_interactable/spawn_interactible** - Spawns an interactible in front of the player. `(spawn_interactable|spawn_interactible) {interactable}`
+* **spawn_portal** - Spawns a portal in front of the player. `spawn_portal {portal ('artifact'|'blue'|'celestial'|'deepvoid'|'gold'|'null'|'void')}`.
 * **spawn_ai** - Spawn an AI. `spawn_ai {ai} [count:1] [elite:None] [braindead (0|1):0/false] [team:Monster]`.
 * **spawn_as** - Spawn as a new character. `spawn_as {body} *[player:<self>]`
 * **spawn_body** - Spawns a CharacterBody with no AI, inventory, or team alliance: `spawn_body {body}`


### PR DESCRIPTION
The behaviour of `add_portal` is quite mixed. It normally adds orbs to the teleporter, but then it spawns the null portal in front of the player only. Then again, the deep void portal, which would have been expected to behave similar to the null portal is actually added to the teleporter while it naturally lacks an orb model. Also, why couldn't then the command spawn the blue portal, for example, in front of the player if the stage has no teleporter?

I propose keeping `add_portal` strictly for the teleporter related portals and creating a new command, `spawn_portal`, which spawns any portal in front of the player.

The infinite portal has been excluded from all of this because there is nothing special about it; it has no special destination and uses the run's next scene. Kind of like a basic teleporter except that it doesn't even roll for the next scene on its own - that's taken care of by the run component itself.