### PR TITLE
Fix next_boss spawning the max allowed count for 0 credit spawn cards

### DIFF
--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -299,11 +299,8 @@ namespace DebugToolkit.Commands
             }
 
             // Unsub the last in case the user already used the command and want to change their mind.
-            On.RoR2.CombatDirector.SetNextSpawnAsBoss -= Hooks.CombatDirector_SetNextSpawnAsBoss;
-            On.RoR2.InfiniteTowerExplicitSpawnWaveController.Initialize -= Hooks.InfiniteTowerExplicitSpawnWaveController_Initialize;
-
-            On.RoR2.CombatDirector.SetNextSpawnAsBoss += Hooks.CombatDirector_SetNextSpawnAsBoss;
-            On.RoR2.InfiniteTowerExplicitSpawnWaveController.Initialize += Hooks.InfiniteTowerExplicitSpawnWaveController_Initialize;
+            Hooks.UndoNextBossHooks();
+            Hooks.ApplyNextBossHooks();
             Log.MessageNetworked(s.ToString(), args);
         }
 


### PR DESCRIPTION
If a zero-cost spawn card is selected, it will not take away from the director's (tailored zero) credits so it won't know to stop at the specific amount and will instead keep going.

We just need to keep a reference to the current boss director and force it to stop at the required amount.