### PR TITLE
Fix the pinged target not being correct for server commands from a client

### DIFF
--- a/Code/DT-Commands/Buffs.cs
+++ b/Code/DT-Commands/Buffs.cs
@@ -556,11 +556,11 @@ namespace DebugToolkit.Commands
             {
                 // Try to get target from the master initially to account for ping -> target revival
                 // as in that case the cached pinged body would be stale.
-                var targetMaster = Util.GetTargetFromArgs(args.userArgs, index, isDedicatedServer);
+                var targetMaster = Util.GetTargetFromArgs(args, index);
                 if (targetMaster == null && !isDedicatedServer && args[index].ToUpperInvariant() == Lang.PINGED)
                 {
                     // Account for masterless bodies
-                    target = Hooks.GetPingedBody();
+                    target = Hooks.GetPingedTarget(args.senderMaster).body;
                     if (target == null)
                     {
                         Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);

--- a/Code/DT-Commands/Items.cs
+++ b/Code/DT-Commands/Items.cs
@@ -580,7 +580,7 @@ namespace DebugToolkit.Commands
                 else
                 {
                     var isDedicatedServer = args.sender == null;
-                    var target = Util.GetTargetFromArgs(args.userArgs, index, isDedicatedServer);
+                    var target = Util.GetTargetFromArgs(args, index);
                     if (target == null && !isDedicatedServer && targetArg == Lang.PINGED)
                     {
                         Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -253,7 +253,7 @@ namespace DebugToolkit.Commands
             CharacterMaster target = args.senderMaster;
             if (args.Count > 0 && args[0] != Lang.DEFAULT_VALUE)
             {
-                target = Util.GetTargetFromArgs(args.userArgs, 0, isDedicatedServer);
+                target = Util.GetTargetFromArgs(args, 0);
                 if (target == null && !isDedicatedServer && args[0].ToUpperInvariant() == Lang.PINGED)
                 {
                     Log.MessageNetworked(Lang.PINGEDBODY_NOTFOUND, args, LogLevel.MessageClientOnly);

--- a/Code/Util.cs
+++ b/Code/Util.cs
@@ -23,19 +23,18 @@ namespace DebugToolkit
         /// <summary>
         /// Find the target CharacterMaster for a matched player string or pinged entity.
         /// </summary>
-        /// <param name="args">(string[])args array</param>
+        /// <param name="args">(ConCommandArgs)command arguments</param>
         /// <param name="index">(int)on the string array, at which index the target string is</param>
-        /// <param name="isDedicatedServer">whether the command has been submitted from a dedicated server</param>
         /// <returns>Returns the found master. Null otherwise</returns>
-        internal static CharacterMaster GetTargetFromArgs(List<string> args, int index, bool isDedicatedServer)
+        internal static CharacterMaster GetTargetFromArgs(ConCommandArgs args, int index)
         {
             if (args.Count > 0 && index < args.Count)
             {
-                if (!isDedicatedServer && args[index].ToUpperInvariant() == Lang.PINGED)
+                if (args.sender != null && args[index].ToUpperInvariant() == Lang.PINGED)
                 {
-                    return Hooks.GetPingedMaster();
+                    return Hooks.GetPingedTarget(args.senderMaster).master;
                 }
-                return GetNetUserFromString(args, index)?.master;
+                return GetNetUserFromString(args.userArgs, index)?.master;
             }
             return null;
         }


### PR DESCRIPTION
Since a server command is executed on the server's machine, a command with a ping target uses whatever ping the server currently has, which defeats the purpose of a client directly controlling the intended target.