### PR TITLE
Make the network object persistent between scene transitions and address noclip toggling cases

### DIFF
--- a/Code/DT-Commands/Command_Noclip.cs
+++ b/Code/DT-Commands/Command_Noclip.cs
@@ -29,7 +29,7 @@ namespace DebugToolkit.Commands
             NetworkManager.DebugToolKitComponents.AddComponent<NoclipNet>();
         }
 
-        internal static void InternalToggle()
+        internal static void InternalToggle(bool shouldLog)
         {
             if (PlayerCommands.UpdateCurrentPlayerBody(out _currentNetworkUser, out _currentBody))
             {
@@ -84,7 +84,10 @@ namespace DebugToolkit.Commands
                 ApplyHooks();
             }
             IsActivated = !IsActivated;
-            Log.Message(string.Format(Lang.NOCLIP_TOGGLE, IsActivated));
+            if (shouldLog)
+            {
+                Log.Message(string.Format(Lang.NOCLIP_TOGGLE, IsActivated));
+            }
         }
 
         private static void ApplyHooks()
@@ -124,8 +127,8 @@ namespace DebugToolkit.Commands
             {
                 if (kcm.CollidableLayers != 0)
                 {
-                    InternalToggle();
-                    InternalToggle();
+                    InternalToggle(false);
+                    InternalToggle(false);
                 }
             }
             else if (rigid)
@@ -133,8 +136,8 @@ namespace DebugToolkit.Commands
                 var collider = rigid.GetComponent<Collider>();
                 if (collider && !collider.isTrigger)
                 {
-                    InternalToggle();
-                    InternalToggle();
+                    InternalToggle(false);
+                    InternalToggle(false);
                 }
             }
 
@@ -192,7 +195,7 @@ namespace DebugToolkit.Commands
         {
             if (IsActivated)
             {
-                InternalToggle();
+                InternalToggle(true);
             }
             orig(self);
         }
@@ -202,11 +205,6 @@ namespace DebugToolkit.Commands
         {
             if (!characterBody.isPlayerControlled)
                 orig(self, characterBody);
-        }
-
-        public static void SetUseGravity(this CharacterMotor motor, bool value)
-        {
-            typeof(CharacterMotor).GetProperty(nameof(CharacterMotor.useGravity)).GetSetMethod(true).Invoke(motor, new object[] { value });
         }
     }
 
@@ -231,7 +229,7 @@ namespace DebugToolkit.Commands
         [TargetRpc]
         private void TargetToggle(NetworkConnection _)
         {
-            Command_Noclip.InternalToggle();
+            Command_Noclip.InternalToggle(true);
         }
     }
 }

--- a/Code/DT-Commands/PlayerCommands.cs
+++ b/Code/DT-Commands/PlayerCommands.cs
@@ -43,11 +43,6 @@ namespace DebugToolkit.Commands
                 Log.MessageNetworked(Lang.NOTINARUN_ERROR, args, LogLevel.MessageClientOnly);
                 return;
             }
-            if (!args.senderBody)
-            {
-                Log.MessageNetworked("Can't toggle noclip while you're dead. " + Lang.USE_RESPAWN, args, LogLevel.MessageClientOnly);
-                return;
-            }
             NoclipNet.Invoke(args.sender); // callback
         }
 

--- a/Code/Hooks.cs
+++ b/Code/Hooks.cs
@@ -57,14 +57,10 @@ namespace DebugToolkit
             On.RoR2.PingerController.RebuildPing += InterceptPing;
             IL.RoR2.InfiniteTowerRun.BeginNextWave += InfiniteTowerRun_BeginNextWave;
 
-            // Noclip hooks
-            var hookConfig = new HookConfig { ManualApply = true };
-            Command_Noclip.OnServerChangeSceneHook = new Hook(typeof(UnityEngine.Networking.NetworkManager).GetMethodCached("ServerChangeScene"),
-    typeof(Command_Noclip).GetMethodCached("DisableOnServerSceneChange"), hookConfig);
-            Command_Noclip.origServerChangeScene = Command_Noclip.OnServerChangeSceneHook.GenerateTrampoline<Command_Noclip.d_ServerChangeScene>();
-            Command_Noclip.OnClientChangeSceneHook = new Hook(typeof(UnityEngine.Networking.NetworkManager).GetMethodCached("ClientChangeScene"),
-                typeof(Command_Noclip).GetMethodCached("DisableOnClientSceneChange"), hookConfig);
-            Command_Noclip.origClientChangeScene = Command_Noclip.OnClientChangeSceneHook.GenerateTrampoline<Command_Noclip.d_ClientChangeScene>();
+            // Networking and noclip hooks
+            On.RoR2.NetworkSession.Start += NetworkManager.CreateNetworkObject;
+            On.RoR2.NetworkSession.OnDestroy += NetworkManager.DestroyNetworkObject;
+            Run.onRunDestroyGlobal += Command_Noclip.DisableOnRunDestroy;
 
             //Buddha Mode hook
             On.RoR2.HealthComponent.TakeDamage += NonLethatDamage;


### PR DESCRIPTION
This is mainly about `noclip` behaviour:
* Change the Disconnect hook to OnStopClient so it is also triggered when the client is kicked or the server drops the session.
* Make it toggleable even while dead, e.g, properly disables noclip when disconnecting while dead.
* Mark the network object DontDestroyOnLoad so that noclip doesn't disable itself when changing scenes, e.g., with `set_scene` and `next_stage`. Teleporting out would retain noclip only because the body would have been destroyed by the time it'd try to toggle it.

Sanity check, players who join midrun still get the network object if spawned only once at the beginning of the network session, right? I tested multiplayer locally and with DropInMultiplayer and it behaves as expected.