### PR TITLE
Improve stage commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 ## Changelog ##
 
+### 3.16 ###
+
+* **3.16.0**
+    * Added `list_scene`
+    * Updated `next_stage`: Adds partial and case-insensitive name matching and also supports the stage language names. Filters out offline scenes from the autocompletion as they are invalid inputs.
+    * Fixed throwing an error when an expansion-locked stage was used for `next_stage` and `set_scene`. A friendly message is printed instead.
+
 ### 3.15 ###
 
 * **3.15.0**

--- a/Code/AutoCompletion/AutoCompleteManager.cs
+++ b/Code/AutoCompletion/AutoCompleteManager.cs
@@ -79,7 +79,7 @@ namespace DebugToolkit
             );
             parser.RegisterStaticVariable("equip", EquipmentCatalog.equipmentDefs.Select(i => $"{i.equipmentIndex}|{i.name}|{StringFinder.GetLangInvar(i.nameToken)}"));
             parser.RegisterStaticVariable("item", ItemCatalog.allItemDefs.Select(i => $"{i.itemIndex}|{i.name}|{StringFinder.GetLangInvar(i.nameToken)}"));
-            parser.RegisterStaticVariable("specific_stage", SceneCatalog.indexToSceneDef.Select(i => i._cachedName));
+            parser.RegisterStaticVariable("specific_stage", SceneCatalog.allSceneDefs.Where(i => !i.isOfflineScene).Select(i => $"{(int)i.sceneDefIndex}|{i.cachedName}|{StringFinder.GetLangInvar(i.nameToken)}"));
 
             parser.RegisterStaticVariable("dot", CollectEnumNames(typeof(DotController.DotIndex), typeof(sbyte)).Skip(1));
             parser.RegisterStaticVariable("permission_level", CollectEnumNames(typeof(Permissions.Level), typeof(int)));

--- a/Code/DT-Commands/CurrentRun.cs
+++ b/Code/DT-Commands/CurrentRun.cs
@@ -276,18 +276,20 @@ namespace DebugToolkit.Commands
                 return;
             }
 
-            string stageString = args[0];
-            var def = Hooks.BetterSceneDefFinder(stageString);
-
-            if (def)
-            {
-                Run.instance.AdvanceStage(def);
-                Log.MessageNetworked($"Stage advanced to {stageString}.", args);
-            }
-            else
+            var sceneIndex = StringFinder.Instance.GetSceneFromPartial(args[0], false);
+            if (sceneIndex == SceneIndex.Invalid)
             {
                 Log.MessageNetworked(Lang.STAGE_NOTFOUND, args, LogLevel.MessageClientOnly);
+                return;
             }
+            var def = SceneCatalog.GetSceneDef(sceneIndex);
+            if (def.requiredExpansion != null && !Run.instance.IsExpansionEnabled(def.requiredExpansion))
+            {
+                Log.MessageNetworked("An expansion is required for this stage.", args, LogLevel.MessageClientOnly);
+                return;
+            }
+            Run.instance.AdvanceStage(def);
+            Log.MessageNetworked($"Stage advanced to {def.cachedName}.", args);
         }
 
         [ConCommand(commandName = "next_wave", flags = ConVarFlags.ExecuteOnServer, helpText = Lang.NEXTWAVE_HELP)]

--- a/Code/DT-Commands/Lists.cs
+++ b/Code/DT-Commands/Lists.cs
@@ -158,6 +158,23 @@ namespace DebugToolkit.Commands
             Log.MessageNetworked(s, args, LogLevel.MessageClientOnly);
         }
 
+        [ConCommand(commandName = "list_scene", flags = ConVarFlags.None, helpText = Lang.LISTSCENE_HELP)]
+        [AutoComplete(Lang.LISTQUERY_ARGS)]
+        private static void CCListScene(ConCommandArgs args)
+        {
+            StringBuilder sb = new StringBuilder();
+            var arg = args.Count > 0 ? args[0] : "";
+            var indices = StringFinder.Instance.GetScenesFromPartial(arg, true);
+            foreach (var index in indices)
+            {
+                var scene = SceneCatalog.GetSceneDef(index);
+                var langInvar = StringFinder.GetLangInvar(scene.nameToken);
+                sb.AppendLine($"[{index}]{scene.cachedName}={langInvar} (offline={scene.isOfflineScene})");
+            }
+            var s = sb.Length > 0 ? sb.ToString().TrimEnd('\n') : string.Format(Lang.NOMATCH_ERROR, "scenes", arg);
+            Log.MessageNetworked(s, args, LogLevel.MessageClientOnly);
+        }
+
         [ConCommand(commandName = "list_skin", flags = ConVarFlags.None, helpText = Lang.LISTSKIN_HELP)]
         [AutoComplete(Lang.LISTSKIN_ARGS)]
         private static void CCListSkin(ConCommandArgs args)

--- a/Code/DebugToolkit.cs
+++ b/Code/DebugToolkit.cs
@@ -17,7 +17,7 @@ namespace DebugToolkit
     [BepInPlugin(GUID, modname, modver)]
     public class DebugToolkit : BaseUnityPlugin
     {
-        public const string modname = "DebugToolkit", modver = "3.15.0";
+        public const string modname = "DebugToolkit", modver = "3.16.0";
         public const string GUID = "iHarbHD." + modname;
 
         internal static ConfigFile Configuration;

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -185,7 +185,7 @@
             PINGEDBODY_NOTFOUND = "Pinged target not found. Either the last ping was not a character, or it has been destroyed since.",
             PLAYER_NOTFOUND = "Specified player not found or isn't alive. Please use list_player for options.",
             SPAWN_ERROR = "Could not spawn: ",
-            STAGE_NOTFOUND = "Stage not found. Please use scene_list for options.",
+            STAGE_NOTFOUND = "Stage not found. Please use list_scene for options.",
             TEAM_NOTFOUND = "Team type not found. Please use list_team for options."
             ;
 

--- a/Code/Lang.cs
+++ b/Code/Lang.cs
@@ -98,6 +98,7 @@
             LISTITEMTIER_HELP = "List all item tiers. " + LISTQUERY_ARGS,
             LISTITEM_HELP = "List all items and their availability. " + LISTQUERY_ARGS,
             LISTPLAYER_HELP = "List all players and their ID. " + LISTQUERY_ARGS,
+            LISTSCENE_HELP = "List all scenes and their language invariants. " + LISTQUERY_ARGS,
             LISTSKIN_HELP = "List all bodies with skins. " + LISTSKIN_ARGS,
             LISTTEAM_HELP = "List all Teams and their language invariants. " + LISTQUERY_ARGS,
             LOADOUTSKIN_HELP = "Change your loadout's skin.  " + LOADOUTSKIN_ARGS,

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -776,7 +776,7 @@ namespace DebugToolkit
                 {
                     matches.Add(new MatchSimilarity
                     {
-                        similarity = Math.Max(GetSimilarity(scene.cachedName, name), GetSimilarity(scene.nameToken, name)),
+                        similarity = Math.Max(GetSimilarity(scene.cachedName, name), GetSimilarity(langInvar, name)),
                         item = scene.sceneDefIndex
                     });
                 }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ List Commands:
 * **list_equip** - List all Equipment, their language invariants, and if they are in the current drop pool.
 * **list_interactables/list_interactibles** List all Interactables.
 * **list_directorcards** List all Director Cards. Mainly used for the `next_boss` command.
+* **list_scene** List all Scenes, their language invariants, and if are they an offline scene.
 * **list_skins** List all Body Skins and the language invariant of the current one in use.
 
 Dump Commands:

--- a/Thunderstore/thunderstore.toml
+++ b/Thunderstore/thunderstore.toml
@@ -4,7 +4,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "IHarbHD"
 name = "DebugToolkit"
-versionNumber = "3.15.0"
+versionNumber = "3.16.0"
 description = "Adds console command for debugging mods."
 websiteUrl = "https://github.com/harbingerofme/DebugToolkit"
 containsNsfwContent = false


### PR DESCRIPTION
Addresses the following issues:

* The vanilla `scene_list` does not map internal to language scene names
* `next_stage` does not support partial/language matching, in contrast to other commands
* `set_scene` and `next_stage` throw an error when an expansion-locked stage is used as the argument