### PR TITLE
Extended catalog compatibility

### DIFF
--- a/Code/AutoCompletion/AutoCompleteManager.cs
+++ b/Code/AutoCompletion/AutoCompleteManager.cs
@@ -104,12 +104,15 @@ namespace DebugToolkit
                 Log.Message("Input type is not enum: " + enumType.Name, Log.LogLevel.Warning, Log.Target.Bepinex);
                 yield break;
             }
-            foreach (var field in enumType.GetFields())
+
+            string[] enumNames = Enum.GetNames(enumType);
+            Array enumValues = Enum.GetValues(enumType);
+
+            for (int i = 0; i < enumValues.Length; i++)
             {
-                var name = field.Name;
-                if (name != "value__" && name != "Count")
+                if (enumNames[i] != "Count")
                 {
-                    yield return $"{Convert.ChangeType(Enum.Parse(enumType, name), castTo)}|{name}";
+                    yield return $"{Convert.ChangeType(enumValues.GetValue(i), castTo)}|{enumNames[i]}";
                 }
             }
         }

--- a/Code/StringFinder.cs
+++ b/Code/StringFinder.cs
@@ -235,7 +235,7 @@ namespace DebugToolkit
             var matches = new List<MatchSimilarity>();
             foreach (var dot in Enum.GetValues(typeof(DotController.DotIndex)).Cast<DotController.DotIndex>())
             {
-                if (dot >= DotController.DotIndex.Bleed && dot < DotController.DotIndex.Count)
+                if (DotController.GetDotDef(dot) != null)
                 {
                     if (dot.ToString().ToUpper().Contains(name))
                     {
@@ -459,7 +459,7 @@ namespace DebugToolkit
             if (TextSerialization.TryParseInvariant(name, out int i))
             {
                 var index = (TeamIndex)i;
-                if (index >= TeamIndex.None && index < TeamIndex.Count)
+                if (index == TeamIndex.None || TeamCatalog.GetTeamDef(index) != null)
                 {
                     yield return index;
                 }
@@ -469,7 +469,7 @@ namespace DebugToolkit
             var matches = new List<MatchSimilarity>();
             foreach (var team in Enum.GetValues(typeof(TeamIndex)).Cast<TeamIndex>().OrderBy(t => t))
             {
-                if (team >= TeamIndex.None && team < TeamIndex.Count)
+                if (team == TeamIndex.None || TeamCatalog.GetTeamDef(team) != null)
                 {
                     if (team.ToString().ToUpper().Contains(name))
                     {


### PR DESCRIPTION
Fixes enum parameters, such as DotIndex and TeamIndex being restricted based on constant `Count` enum values, as this does not work for catalogs where entries exceed the number of enum values. Also would no longer need a recompile if a new Team or DotIndex was added.

Also fixes `AutoCompleteManager.CollectEnumNames` being incompatible with runtime enum patches (Utilized by R2API.Teams).